### PR TITLE
Implement dungeon run counter and bug report button

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,8 +113,8 @@ def calculate_fight_stats(team, enemy_def, level_scaling):
     disadvantageous_heroes = sum(1 for el in team_elements if advantage.get(enemy_element) == el)
     team_elemental_multiplier = 1.0 + (0.25 * advantageous_heroes) - (0.25 * disadvantageous_heroes)
 
-    enemy_hp = enemy_def['base_hp'] * (1 + (level_scaling - 1) * 0.25) * random.uniform(0.9, 1.1)
-    enemy_atk = enemy_def['base_atk'] * (1 + (level_scaling - 1) * 0.15) * random.uniform(0.9, 1.1)
+    enemy_hp = enemy_def['base_hp'] * (1 + (level_scaling - 1) * 0.25)
+    enemy_atk = enemy_def['base_atk'] * (1 + (level_scaling - 1) * 0.15)
     enemy_crit_chance = enemy_def.get('crit_chance', 0)
     enemy_crit_damage = enemy_def.get('crit_damage', 1.5)
 
@@ -177,8 +177,12 @@ def get_player_data():
     player_data = db.get_player_data(user_id)
     player_team = db.get_player_team(user_id, character_definitions)
     full_data = {
-        'username': session.get('username'), 'gems': player_data['gems'], 'current_stage': player_data['current_stage'],
-        'team': player_team, 'collection': player_data['collection']
+        'username': session.get('username'),
+        'gems': player_data['gems'],
+        'current_stage': player_data['current_stage'],
+        'dungeon_runs': player_data.get('dungeon_runs', 0),
+        'team': player_team,
+        'collection': player_data['collection']
     }
     return jsonify({'success': True, 'data': full_data})
 
@@ -311,6 +315,8 @@ def fight_dungeon():
             conn.close()
     else:
         combat_log.append({'type': 'end', 'message': "--- DEFEAT! ---"})
+
+    db.increment_dungeon_runs(user_id)
     return jsonify({'success': True, 'victory': victory, 'log': combat_log, 'gems_won': 0, 'looted_item': looted_item})
 
 

--- a/database.py
+++ b/database.py
@@ -23,6 +23,7 @@ def init_db():
             user_id INTEGER PRIMARY KEY,
             gems INTEGER NOT NULL DEFAULT 100,
             current_stage INTEGER NOT NULL DEFAULT 1,
+            dungeon_runs INTEGER NOT NULL DEFAULT 0,
             FOREIGN KEY (user_id) REFERENCES users (id)
         )
     ''')
@@ -98,6 +99,12 @@ def get_player_data(user_id):
 def save_player_data(user_id, gems, current_stage):
     conn = get_db_connection()
     conn.execute("UPDATE player_data SET gems = ?, current_stage = ? WHERE user_id = ?", (gems, current_stage, user_id))
+    conn.commit()
+    conn.close()
+
+def increment_dungeon_runs(user_id):
+    conn = get_db_connection()
+    conn.execute("UPDATE player_data SET dungeon_runs = dungeon_runs + 1 WHERE user_id = ?", (user_id,))
     conn.commit()
     conn.close()
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -22,8 +22,10 @@ const registerButton = document.getElementById('register-button');
 const playerNameDisplay = document.getElementById('player-name');
 const gemCountDisplay = document.getElementById('gem-count');
 const logoutButton = document.getElementById('logout-button');
+const bugButton = document.getElementById('report-bug-button');
 const mainContent = document.getElementById('main-content');
 const teamDisplayContainer = document.getElementById('team-display');
+const dungeonRunCount = document.getElementById('dungeon-run-count');
 const collectionContainer = document.getElementById('collection-container');
 const summonButton = document.getElementById('perform-summon-button');
 const summonResultContainer = document.getElementById('summon-result');
@@ -72,6 +74,11 @@ function attachEventListeners() {
     });
 
     logoutButton.addEventListener('click', handleLogout);
+    if (bugButton) {
+        bugButton.addEventListener('click', () => {
+            window.open('https://github.com/your_username/your_repo/issues', '_blank');
+        });
+    }
 
     summonButton.addEventListener('click', async () => {
         const response = await fetch('/api/summon', { method: 'POST' });
@@ -305,6 +312,7 @@ function updateUI() {
     if (!gameState || !gameState.username) return;
     playerNameDisplay.textContent = gameState.username;
     gemCountDisplay.textContent = gameState.gems;
+    if (dungeonRunCount) dungeonRunCount.textContent = gameState.dungeon_runs;
     updateTeamDisplay();
     updateCollectionDisplay();
     updateCampaignDisplay();
@@ -373,6 +381,12 @@ function updateCollectionDisplay() {
         const canMerge = heroGroup.length >= mergeCost;
         const isInTeam = teamDBIds.includes(heroInstance.id);
         card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${heroInstance.rarity.toLowerCase()}">[${heroInstance.rarity}] (x${heroGroup.length})</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img src="/static/images/characters/${charDef.image_file}" alt="${name}"><h4>${name}</h4><div class="card-stats">ATK: ${charDef.base_atk} | HP: ${charDef.base_hp}</div><div class="card-stats">Crit: ${charDef.crit_chance}% | Crit DMG: ${charDef.crit_damage}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${heroInstance.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${name}" ${canMerge ? '' : 'disabled'}>Merge</button></div>`;
+        if (isInTeam) {
+            const indicator = document.createElement('div');
+            indicator.className = 'in-team-indicator';
+            indicator.textContent = '★';
+            card.appendChild(indicator);
+        }
         collectionContainer.appendChild(card);
     }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,7 @@
             <div id="currency-info">
                 <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" alt="Gems">
                 <span id="gem-count"></span>
+                <button id="report-bug-button">Report Bug</button>
             </div>
         </div>
 
@@ -71,6 +72,7 @@
             <div id="home-view" class="view active">
                 <h2>Your Active Team</h2>
                 <div id="team-display" class="team-container"></div>
+                <p id="dungeon-run-info">Dungeon Runs: <span id="dungeon-run-count">0</span></p>
 
                     <!-- === NEW MESSAGE OF THE DAY SECTION === -->
     <div id="motd-container" class="motd-box">


### PR DESCRIPTION
## Summary
- add `dungeon_runs` column and increment helper in `database.py`
- make tower enemy scaling deterministic
- expose dungeon run count to clients
- track dungeon runs after each dungeon fight
- show run count and report-bug button on the UI
- highlight heroes that are on the current team

## Testing
- `python -m py_compile app.py database.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685c69ba18688333b05d8122e795581c