### PR TITLE
Implement currency and leveling features with pity system

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,7 @@
             <div id="currency-info">
                 <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" alt="Gems">
                 <span id="gem-count"></span>
+                <span>Gold:</span> <span id="gold-count"></span>
                 <button id="report-bug-button">Report Bug</button>
             </div>
         </div>
@@ -108,7 +109,7 @@
             <div id="summon-view" class="view">
                 <div class="summon-area">
                     <h2>The Summoning Altar</h2>
-                    <p>Use 50 Gems to summon a new hero!</p>
+                    <p>Use 150 Gems to summon a new hero!</p>
                     <button id="perform-summon-button">Summon</button>
                     <div id="summon-result" class="summon-result-box"></div>
                 </div>


### PR DESCRIPTION
## Summary
- add `gold` and `pity_counter` columns plus hero `level` and `dupe_level`
- extend database helper functions for new fields
- implement pity system and level-up endpoint in API
- award gold in battles
- display gold and hero levels in the UI
- allow characters to level up from the hero detail modal

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_685c90792c488333a9e4b5d940987153