### PR TITLE
Add registration modal and UI updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,7 +157,7 @@ def get_lore():
 @app.route('/api/register', methods=['POST'])
 def register():
     data = request.json
-    result = db.register_user(data.get('username'), data.get('password'))
+    result = db.register_user(data.get('username'), data.get('email'), data.get('password'))
     return jsonify({'success': result == "Success", 'message': result})
 
 

--- a/database.py
+++ b/database.py
@@ -23,6 +23,7 @@ def init_db():
         CREATE TABLE IF NOT EXISTS users (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE NOT NULL,
+            email TEXT,
             password TEXT NOT NULL
         )
     ''')
@@ -68,18 +69,23 @@ def init_db():
     ''')
     conn.commit()
     # Ensure new columns exist for existing databases
+    add_column_if_missing(conn, 'users', 'email', 'TEXT')
     add_column_if_missing(conn, 'player_data', 'gold', 'INTEGER NOT NULL DEFAULT 10000')
     add_column_if_missing(conn, 'player_data', 'pity_counter', 'INTEGER NOT NULL DEFAULT 0')
     add_column_if_missing(conn, 'player_characters', 'level', 'INTEGER NOT NULL DEFAULT 1')
     add_column_if_missing(conn, 'player_characters', 'dupe_level', 'INTEGER NOT NULL DEFAULT 0')
     conn.close()
 
-def register_user(username, password):
-    if not username or not password: return "Username and password are required."
+def register_user(username, email, password):
+    if not username or not password:
+        return "Username and password are required."
     conn = get_db_connection()
     try:
         cursor = conn.cursor()
-        cursor.execute("INSERT INTO users (username, password) VALUES (?, ?)", (username, password))
+        cursor.execute(
+            "INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
+            (username, email, password)
+        )
         user_id = cursor.lastrowid
         cursor.execute(
             "INSERT INTO player_data (user_id, gems, gold, pity_counter) VALUES (?, ?, ?, 0)",

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -104,6 +104,17 @@ button:disabled, .fantasy-button:disabled {
     color: white;
     font-size: 16px;
 }
+#register-modal-overlay input {
+    display: block;
+    width: 250px;
+    padding: 10px;
+    margin: 8px auto;
+    border-radius: 5px;
+    border: 1px solid #555;
+    background-color: #333;
+    color: white;
+    font-size: 16px;
+}
 .button-group button {
     padding: 10px 30px;
     margin: 10px;
@@ -113,6 +124,15 @@ button:disabled, .fantasy-button:disabled {
     background-color: #555;
     color: white;
     border-radius: 5px;
+}
+#forgot-password-link {
+    display: block;
+    margin-top: 10px;
+    color: #3498db;
+    text-decoration: none;
+}
+#forgot-password-link:hover {
+    text-decoration: underline;
 }
 
 /* Main Game Screen Layout */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -45,6 +45,13 @@ const equipmentContainer = document.getElementById('equipment-container');
 const heroImageOverlay = document.getElementById('hero-image-overlay');
 const heroImageLarge = document.getElementById('hero-image-large');
 const messageBox = document.getElementById('message-box');
+const registerModal = document.getElementById('register-modal-overlay');
+const regUsernameInput = document.getElementById('reg-username');
+const regEmailInput = document.getElementById('reg-email');
+const regPasswordInput = document.getElementById('reg-password');
+const regConfirmInput = document.getElementById('reg-confirm-password');
+const regSubmitBtn = document.getElementById('register-submit-btn');
+const regCancelBtn = document.getElementById('register-cancel-btn');
 
 function displayMessage(text) {
     if (!messageBox) return;
@@ -82,9 +89,33 @@ function attachEventListeners() {
     loginButton.addEventListener('click', handleLogin);
     passwordInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleLogin(); });
 
-    registerButton.addEventListener('click', async () => {
-        const response = await fetch('/api/register', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ username: usernameInput.value, password: passwordInput.value }) });
-        displayMessage((await response.json()).message);
+    registerButton.addEventListener('click', () => {
+        registerModal.classList.add('active');
+    });
+
+    regCancelBtn.addEventListener('click', () => {
+        registerModal.classList.remove('active');
+    });
+
+    regSubmitBtn.addEventListener('click', async () => {
+        if (regPasswordInput.value !== regConfirmInput.value) {
+            displayMessage('Passwords do not match');
+            return;
+        }
+        const response = await fetch('/api/register', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                username: regUsernameInput.value,
+                email: regEmailInput.value,
+                password: regPasswordInput.value
+            })
+        });
+        const result = await response.json();
+        displayMessage(result.message);
+        if (result.success) {
+            registerModal.classList.remove('active');
+        }
     });
 
     logoutButton.addEventListener('click', handleLogout);

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,7 @@
                     <button id="login-button">Login</button>
                     <button id="register-button">Register</button>
                 </div>
+                <a href="#" id="forgot-password-link">Forgot Password?</a>
 
         <!-- === NEW VIDEO PLACEHOLDER === -->
         <div class="video-container">
@@ -327,6 +328,20 @@
     <div class="modal-content">
         <p id="tutorial-text"></p>
         <button id="tutorial-close-btn">Close</button>
+    </div>
+</div>
+
+<div id="register-modal-overlay" class="modal-overlay">
+    <div class="modal-content">
+        <h3>Create Account</h3>
+        <input type="text" id="reg-username" placeholder="Username">
+        <input type="email" id="reg-email" placeholder="Email">
+        <input type="password" id="reg-password" placeholder="Password">
+        <input type="password" id="reg-confirm-password" placeholder="Confirm Password">
+        <div class="modal-buttons">
+            <button id="register-submit-btn">Register</button>
+            <button id="register-cancel-btn">Cancel</button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add forgot-password link on login
- implement registration modal for username/email/password/confirmation
- show/hide modal from JS and send data via API
- store email in database and API
- style modal inputs and forgot password link

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb99016148333a3b20d155c4a53ab