### PR TITLE
Fix dungeon fight loot generation bug

### DIFF
--- a/app.py
+++ b/app.py
@@ -341,6 +341,7 @@ def fight_dungeon():
     concept = random.choice(enemy_definitions)
     dungeon_archetype = random.choice(["standard", "tank", "glass_cannon", "swift"])
     enemy = generate_enemy(ARMORY_FIXED_LEVEL, dungeon_archetype, concept)
+    enemy_level = enemy['level']
 
     stats = calculate_fight_stats(team, enemy)
     team_hp, enemy_hp = stats['team_hp'], stats['enemy_hp']


### PR DESCRIPTION
## Summary
- ensure dungeon fights track the enemy level before awarding loot

## Testing
- `python3 -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685cbab180048333b7ed7ccbacfca706