### PR TITLE
Fix hero duplication and UI tweaks

### DIFF
--- a/database.py
+++ b/database.py
@@ -143,17 +143,10 @@ def increment_dungeon_runs(user_id):
 def add_character_to_player(user_id, char_def):
     conn = get_db_connection()
     cursor = conn.cursor()
-    existing = cursor.execute(
-        "SELECT id FROM player_characters WHERE user_id = ? AND character_name = ? ORDER BY id LIMIT 1",
-        (user_id, char_def['name'])
-    ).fetchone()
-    if existing:
-        cursor.execute("UPDATE player_characters SET dupe_level = dupe_level + 1 WHERE id = ?", (existing['id'],))
-    else:
-        cursor.execute(
-            "INSERT INTO player_characters (user_id, character_name, rarity, level, dupe_level) VALUES (?, ?, ?, 1, 0)",
-            (user_id, char_def['name'], char_def['rarity'])
-        )
+    cursor.execute(
+        "INSERT INTO player_characters (user_id, character_name, rarity, level, dupe_level) VALUES (?, ?, ?, 1, 0)",
+        (user_id, char_def['name'], char_def['rarity'])
+    )
     conn.commit()
     conn.close()
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -856,6 +856,11 @@ button:disabled, .fantasy-button:disabled {
     position: static;
 }
 
+/* Center the tower header content */
+#tower-lore-header .section-header {
+    justify-content: center;
+}
+
 .heroes-guide {
     background: rgba(0,0,0,0.4);
     padding: 10px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@
             <div id="collection-view" class="view">
                 <div class="section-header">
                     <h2>Your Hero Collection</h2>
-                    <button class="tutorial-btn" data-tutorial="Manage your heroes here. 🔥 Fire is strong against 🌿 Grass (Fire burns Grass). 🌿 Grass is strong against 💧 Water (Grass soaks up Water). 💧 Water is strong against 🔥 Fire (Water douses Fire). Stats and critical hits decide combat results.">?</button>
+                    <button class="tutorial-btn" data-tutorial="Manage your heroes here. Gold is used to level up heroes and boost their stats. 🔥 Fire is strong against 🌿 Grass (Fire burns Grass). 🌿 Grass is strong against 💧 Water (Grass soaks up Water). 💧 Water is strong against 🔥 Fire (Water douses Fire). Stats and critical hits decide combat results.">?</button>
                 </div>
                 <div class="heroes-guide">
                     <h3>Elemental Synergy</h3>
@@ -275,10 +275,10 @@
     </div>
 
     <!-- CHAT FEATURE -->
-    <div id="chat-container" class="collapsed">
+    <div id="chat-container">
         <div id="chat-header">
             <h3>World Chat</h3>
-            <button id="chat-toggle-btn">▴</button>
+            <button id="chat-toggle-btn">▾</button>
         </div>
         <div id="chat-messages"></div>
         <div id="chat-input-area">


### PR DESCRIPTION
## Summary
- allow duplicate hero records in the database
- mention gold use in hero section tutorial
- open chat by default
- center tower section header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cbbdd11f08333afaebaccf3b3abe8