### PR TITLE
Fix hero gold scaling and add selling option

### DIFF
--- a/app.py
+++ b/app.py
@@ -81,8 +81,10 @@ def calculate_fight_stats(team, enemy):
 
         try:
             # Start with base stats
-            char_hp = character['base_hp'] * STAT_MULTIPLIER.get(character['rarity'], 1.0)
-            char_atk = character['base_atk'] * STAT_MULTIPLIER.get(character['rarity'], 1.0)
+            level = character.get('level', 1)
+            level_mult = 1 + 0.10 * (level - 1)
+            char_hp = character['base_hp'] * STAT_MULTIPLIER.get(character['rarity'], 1.0) * level_mult
+            char_atk = character['base_atk'] * STAT_MULTIPLIER.get(character['rarity'], 1.0) * level_mult
             char_crit_chance = character.get('crit_chance', 0)
             char_crit_damage = character.get('crit_damage', 1.5)
 
@@ -483,6 +485,19 @@ def level_up():
     success, result = db.level_up_character(user_id, char_id)
     if success:
         return jsonify({'success': True, 'new_level': result['new_level'], 'new_gold': result['new_gold']})
+    else:
+        return jsonify({'success': False, 'message': result})
+
+
+@app.route('/api/sell_hero', methods=['POST'])
+def sell_hero():
+    if not session.get('logged_in'):
+        return jsonify({'success': False}), 401
+    user_id = session['user_id']
+    char_id = request.json.get('char_id')
+    success, result = db.sell_character(user_id, char_id)
+    if success:
+        return jsonify({'success': True, 'gold_received': result['gold_received'], 'new_gold': result['new_gold']})
     else:
         return jsonify({'success': False, 'message': result})
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -256,11 +256,19 @@ function attachEventListeners() {
             document.getElementById('hero-detail-overlay').classList.remove('active');
             await fetchPlayerDataAndUpdate();
         }
-        else if (target.id === 'level-up-btn') {
+        else if (target.classList.contains('level-up-card-btn')) {
             const heroId = target.dataset.heroId;
             const response = await fetch('/api/level_up', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ char_id: parseInt(heroId) }) });
             const result = await response.json();
             if (!result.success) displayMessage(result.message);
+            await fetchPlayerDataAndUpdate();
+        }
+        else if (target.classList.contains('sell-hero-btn')) {
+            const heroId = target.dataset.heroId;
+            const response = await fetch('/api/sell_hero', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ char_id: parseInt(heroId) }) });
+            const result = await response.json();
+            if (result.success) displayMessage(`Sold for ${result.gold_received} gold`);
+            else displayMessage(result.message);
             await fetchPlayerDataAndUpdate();
         }
         else if (target.classList.contains('unequip-btn')) {
@@ -381,7 +389,6 @@ async function openHeroDetailModal(hero) {
         </select>
         <div class="modal-buttons">
             <button id="confirm-equip-btn" data-hero-id="${fullHeroData.id}">Equip Selected</button>
-            <button id="level-up-btn" data-hero-id="${fullHeroData.id}">Level Up (${100 * fullHeroData.level} Gold)</button>
             <button id="close-hero-detail-btn">Close</button>
         </div>
     `;
@@ -501,7 +508,7 @@ function updateCollectionDisplay() {
         const mergeCost = {'Common': 3, 'Rare': 3, 'SSR': 4, 'UR': 5}[hero.rarity] || 999;
         const canMerge = heroCounts[hero.character_name] >= mergeCost;
         const isInTeam = teamDBIds.includes(hero.id);
-        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level} | Dupes: ${hero.dupe_level}</div><div class="card-stats">ATK: ${charDef.base_atk} | HP: ${charDef.base_hp}</div><div class="card-stats">Crit: ${charDef.crit_chance}% | Crit DMG: ${charDef.crit_damage}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button></div>`;
+        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level} | Dupes: ${hero.dupe_level}</div><div class="card-stats">ATK: ${charDef.base_atk} | HP: ${charDef.base_hp}</div><div class="card-stats">Crit: ${charDef.crit_chance}% | Crit DMG: ${charDef.crit_damage}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button><button class="level-up-card-btn" data-hero-id="${hero.id}">Level Up (${100 * hero.level})</button><button class="sell-hero-btn" data-hero-id="${hero.id}">Sell</button></div>`;
         if (isInTeam) {
             const indicator = document.createElement('div');
             indicator.className = 'in-team-indicator';


### PR DESCRIPTION
## Summary
- scale hero stats with level so gold leveling works
- add endpoint and button to sell heroes for gold
- relocate level up button to hero card and remove from detail modal

## Testing
- `python3 -m py_compile app.py database.py balance.py`
- `node -c static/js/app.js`

------
https://chatgpt.com/codex/tasks/task_e_685da2627be083339d5d6c87fcc0f2f3