### PR TITLE
Add energy system and rename premium currency

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -63,10 +63,14 @@
             <div id="currency-info">
                 <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" alt="Gems">
                 <span id="gem-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Premium Gems">
-                <span id="premium-gem-count"></span>
+                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Platinum">
+                <span id="platinum-count"></span>
                 <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Gold">
                 <span id="gold-count"></span>
+                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Energy">
+                <span id="energy-count"></span>
+                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Dungeon Energy">
+                <span id="dungeon-energy-count"></span>
                 <button id="report-bug-button">Report Bug</button>
             </div>
         </div>
@@ -143,8 +147,8 @@
             <!-- Store View -->
             <div id="store-view" class="view">
                 <div class="section-header">
-                    <h2>Premium Shop</h2>
-                    <button class="tutorial-btn" data-tutorial="Purchase premium gems here. Transactions are verified server-side.">?</button>
+                    <h2>Platinum Shop</h2>
+                    <button class="tutorial-btn" data-tutorial="Purchase Platinum or energy here. Transactions are verified server-side.">?</button>
                 </div>
                 <div id="store-packages" class="store-container"></div>
             </div>


### PR DESCRIPTION
## Summary
- implement hourly tower energy and daily dungeon energy with DB columns
- add energy items in the store and generic item purchase endpoint
- enforce energy costs for tower floors and dungeon battles
- display Platinum and energy values in UI
- rename premium currency references to "Platinum"

## Testing
- `python -m py_compile app.py database.py balance.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de1f6db4c833390e501f9a775f36d