### PR TITLE
Add PayPal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Gatcha Game
+
+This repository contains a Flask-based gacha game.
+
+## PayPal Integration
+
+The store can now process payments via PayPal. Configure your PayPal client ID and secret from the Admin Panel. Once configured, PayPal buttons appear in the store for premium currency purchases.
+
+### Managing PayPal Credentials
+1. Login as an admin user.
+2. Open the **Admin** tab.
+3. Fill in `PayPal Client ID` and `PayPal Secret` fields.
+4. Click **Save PayPal** to apply the settings.
+
+These values are stored in the database and used by the server when rendering PayPal buttons.

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ python-socketio==5.13.0
 simple-websocket==1.1.0
 Werkzeug==3.1.3
 wsproto==1.2.0
+paypalrestsdk==1.14.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,7 @@
     <!-- ================================ -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+    <script id="paypal-sdk"></script>
 </head>
 <body>
 
@@ -252,6 +253,10 @@
                 <input type="number" id="admin-gold" placeholder="Gold">
                 <input type="text" id="admin-character-name" placeholder="Hero name or ID">
                 <button id="admin-submit-btn">Execute</button>
+                <hr>
+                <input type="text" id="admin-paypal-client-id" placeholder="PayPal Client ID">
+                <input type="text" id="admin-paypal-secret" placeholder="PayPal Secret">
+                <button id="admin-paypal-save-btn">Save PayPal</button>
             </div>
 
 


### PR DESCRIPTION
## Summary
- create README detailing PayPal setup
- allow storing PayPal credentials in database
- configure PayPal SDK on startup
- expose PayPal API endpoints
- display PayPal buttons in store
- manage PayPal account from admin panel

## Testing
- `python3 -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_685de66d85ac833381297a8563536bb7