### PR TITLE
Implement password reset and registration validation

### DIFF
--- a/database.py
+++ b/database.py
@@ -415,6 +415,18 @@ def get_user_id(username):
     conn.close()
     return row['id'] if row else None
 
+def reset_password(email, new_password):
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    row = cursor.execute("SELECT id FROM users WHERE email = ?", (email,)).fetchone()
+    if not row:
+        conn.close()
+        return False
+    cursor.execute("UPDATE users SET password = ? WHERE email = ?", (new_password, email))
+    conn.commit()
+    conn.close()
+    return True
+
 def adjust_resources(user_id, gems=None, premium_gems=None, energy=None, gold=None):
     save_player_data(user_id, gems=gems, premium_gems=premium_gems, energy=energy, gold=gold)
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -47,6 +47,7 @@ const battleScreen = document.getElementById('battle-screen');
 const equipmentContainer = document.getElementById('equipment-container');
 const storePackagesContainer = document.getElementById('store-packages');
 const userIcon = document.getElementById('user-icon');
+const forgotPasswordLink = document.getElementById('forgot-password-link');
 let profileModal;
 let profileEmailInput;
 let profilePasswordInput;
@@ -67,12 +68,26 @@ let regPasswordInput;
 let regConfirmInput;
 let regSubmitBtn;
 let regCancelBtn;
+let forgotModal;
+let forgotEmailInput;
+let forgotPasswordInput;
+let forgotConfirmInput;
+let forgotSubmitBtn;
+let forgotCancelBtn;
 
 function displayMessage(text) {
     if (!messageBox) return;
     messageBox.textContent = text;
     messageBox.style.display = 'block';
     setTimeout(() => { messageBox.style.display = 'none'; }, 3000);
+}
+
+function isValidEmail(email) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function isValidPassword(pwd) {
+    return /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10}$/.test(pwd);
 }
 const TOWER_LORE = [
     {
@@ -122,6 +137,12 @@ function attachEventListeners() {
     regConfirmInput = document.getElementById('reg-confirm-password');
     regSubmitBtn = document.getElementById('register-submit-btn');
     regCancelBtn = document.getElementById('register-cancel-btn');
+    forgotModal = document.getElementById('forgot-password-modal');
+    forgotEmailInput = document.getElementById('forgot-email');
+    forgotPasswordInput = document.getElementById('forgot-password');
+    forgotConfirmInput = document.getElementById('forgot-confirm-password');
+    forgotSubmitBtn = document.getElementById('forgot-submit-btn');
+    forgotCancelBtn = document.getElementById('forgot-cancel-btn');
 
     loginButton.addEventListener('click', handleLogin);
     passwordInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleLogin(); });
@@ -137,6 +158,14 @@ function attachEventListeners() {
     }
 
     if (regSubmitBtn) regSubmitBtn.addEventListener('click', async () => {
+        if (!isValidEmail(regEmailInput.value)) {
+            displayMessage('Invalid email format');
+            return;
+        }
+        if (!isValidPassword(regPasswordInput.value)) {
+            displayMessage('Password must be 10 characters with letters and numbers');
+            return;
+        }
         if (regPasswordInput.value !== regConfirmInput.value) {
             displayMessage('Passwords do not match');
             return;
@@ -155,6 +184,38 @@ function attachEventListeners() {
         if (result.success && registerModal) {
             registerModal.classList.remove('active');
         }
+    });
+
+    if (forgotPasswordLink) forgotPasswordLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        if (forgotModal) forgotModal.classList.add('active');
+    });
+
+    if (forgotCancelBtn) forgotCancelBtn.addEventListener('click', () => {
+        if (forgotModal) forgotModal.classList.remove('active');
+    });
+
+    if (forgotSubmitBtn) forgotSubmitBtn.addEventListener('click', async () => {
+        if (!isValidEmail(forgotEmailInput.value)) {
+            displayMessage('Invalid email format');
+            return;
+        }
+        if (!isValidPassword(forgotPasswordInput.value)) {
+            displayMessage('Password must be 10 characters with letters and numbers');
+            return;
+        }
+        if (forgotPasswordInput.value !== forgotConfirmInput.value) {
+            displayMessage('Passwords do not match');
+            return;
+        }
+        const response = await fetch('/api/forgot_password', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: forgotEmailInput.value, password: forgotPasswordInput.value })
+        });
+        const result = await response.json();
+        displayMessage(result.message);
+        if (result.success && forgotModal) forgotModal.classList.remove('active');
     });
 
     logoutButton.addEventListener('click', handleLogout);

--- a/templates/index.html
+++ b/templates/index.html
@@ -403,6 +403,19 @@
     </div>
 </div>
 
+<div id="forgot-password-modal" class="modal-overlay">
+    <div class="modal-content">
+        <h3>Reset Password</h3>
+        <input type="email" id="forgot-email" placeholder="Email">
+        <input type="password" id="forgot-password" placeholder="New Password">
+        <input type="password" id="forgot-confirm-password" placeholder="Confirm Password">
+        <div class="modal-buttons">
+            <button id="forgot-submit-btn">Submit</button>
+            <button id="forgot-cancel-btn">Cancel</button>
+        </div>
+    </div>
+</div>
+
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- validate email and enforce a 10-character alphanumeric password on registration
- add forgot password modal and client-side handlers
- implement `/api/forgot_password` route
- support updating password in the database by email

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685de8491b888333a35368813788b9d2