### PR TITLE
Fix SQLite lock on init_db

### DIFF
--- a/database.py
+++ b/database.py
@@ -94,6 +94,8 @@ def init_db():
     add_column_if_missing(conn, 'player_characters', 'level', 'INTEGER NOT NULL DEFAULT 1')
     add_column_if_missing(conn, 'player_characters', 'dupe_level', 'INTEGER NOT NULL DEFAULT 0')
     cursor.execute('INSERT OR IGNORE INTO paypal_config (id, client_id, client_secret) VALUES (1, "", "")')
+    # Commit before opening a new connection in create_admin_if_missing
+    conn.commit()
     create_admin_if_missing()
     conn.close()
 


### PR DESCRIPTION
## Summary
- prevent `database is locked` error when starting in debug
- commit connection before `create_admin_if_missing`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685deee6a05c8333b7e6e0f701e1e6b9