### PR TITLE
Add profile modal polish and hide chat until login

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -115,6 +115,25 @@ button:disabled, .fantasy-button:disabled {
     color: white;
     font-size: 16px;
 }
+
+#profile-modal input,
+#profile-modal select {
+    display: block;
+    width: 250px;
+    padding: 10px;
+    margin: 8px auto;
+    border-radius: 5px;
+    border: 1px solid #555;
+    background-color: #333;
+    color: white;
+    font-size: 16px;
+}
+
+#profile-modal .modal-content h3 {
+    margin-bottom: 10px;
+    font-size: 24px;
+    color: #f0c44c;
+}
 .button-group button {
     padding: 10px 30px;
     margin: 10px;
@@ -853,6 +872,10 @@ button:disabled, .fantasy-button:disabled {
 
 .admin-only {
     display: none;
+}
+
+.hidden {
+    display: none !important;
 }
 
 /* Simple round button used for tutorial pop ups */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -238,24 +238,8 @@ function attachEventListeners() {
         });
     }
 
-    if (playerNameDisplay) {
-        playerNameDisplay.addEventListener('click', () => {
-            if (!profileModal) return;
-            profileEmailInput.value = gameState.email || '';
-            profileCurrentPasswordInput.value = '';
-            profileNewPasswordInput.value = '';
-            profileConfirmPasswordInput.value = '';
-            profileImageSelect.innerHTML = '';
-            masterCharacterList.forEach(c => {
-                const opt = document.createElement('option');
-                opt.value = c.image_file;
-                opt.textContent = c.name;
-                if (gameState.profile_image === c.image_file) opt.selected = true;
-                profileImageSelect.appendChild(opt);
-            });
-            profileModal.classList.add('active');
-        });
-    }
+    if (playerNameDisplay) playerNameDisplay.addEventListener('click', openProfileModal);
+    if (userIcon) userIcon.addEventListener('click', openProfileModal);
     if (profileCancelBtn) profileCancelBtn.addEventListener('click', () => profileModal.classList.remove('active'));
     if (profileSaveBtn) profileSaveBtn.addEventListener('click', async () => {
         const response = await fetch('/api/update_profile', {
@@ -572,10 +556,12 @@ async function initializeGame() {
     if (loggedIn) {
         loginScreen.classList.remove('active');
         gameScreen.classList.add('active');
+        if (chatContainer) chatContainer.classList.remove('hidden');
         connectSocket();
     } else {
         loginScreen.classList.add('active');
         gameScreen.classList.remove('active');
+        if (chatContainer) chatContainer.classList.add('hidden');
     }
 }
 
@@ -611,6 +597,7 @@ async function handleLogout() {
     gameState = {};
     loginScreen.classList.add('active');
     gameScreen.classList.remove('active');
+    if (chatContainer) chatContainer.classList.add('hidden');
     usernameInput.value = '';
     passwordInput.value = '';
 }
@@ -672,6 +659,22 @@ async function openHeroDetailModal(hero) {
     modalContent.innerHTML = html;
 }
 
+function openProfileModal() {
+    if (!profileModal) return;
+    profileEmailInput.value = gameState.email || '';
+    profileCurrentPasswordInput.value = '';
+    profileNewPasswordInput.value = '';
+    profileConfirmPasswordInput.value = '';
+    profileImageSelect.innerHTML = '';
+    masterCharacterList.forEach(c => {
+        const opt = document.createElement('option');
+        opt.value = c.image_file;
+        opt.textContent = c.name;
+        if (gameState.profile_image === c.image_file) opt.selected = true;
+        profileImageSelect.appendChild(opt);
+    });
+    profileModal.classList.add('active');
+}
 
 function sendMessage() {
     if (chatInput.value.trim() !== '') {

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,7 +57,7 @@
         <!-- TOP BAR: Player Info -->
         <div id="top-bar">
             <div id="player-info">
-                <img id="user-icon" src="{{ url_for('static', filename='images/ui/placeholder_char.png') }}" alt="User Icon" class="user-icon">
+                <img id="user-icon" src="{{ url_for('static', filename='images/ui/placeholder_char.png') }}" alt="User Icon" class="user-icon clickable">
                 <span id="player-name" class="clickable"></span>
                 <button id="logout-button">Logout</button>
             </div>
@@ -325,7 +325,7 @@
     </div>
 
     <!-- CHAT FEATURE -->
-    <div id="chat-container">
+    <div id="chat-container" class="hidden">
         <div id="chat-header">
             <h3>World Chat</h3>
             <button id="chat-toggle-btn">▾</button>


### PR DESCRIPTION
## Summary
- polish user profile modal styles
- make user icon open the profile modal
- hide chat until user logs in

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eb0bfd7a48333851a146eeeba1853