### PR TITLE
Fix PayPal button display without refresh

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -305,6 +305,8 @@ function attachEventListeners() {
         });
         const result = await response.json();
         displayMessage(result.success ? 'PayPal settings saved' : 'Update failed');
+        // Refresh the store so PayPal buttons appear without a full page reload
+        updateStoreDisplay();
     });
     if (adminMotdSaveBtn) adminMotdSaveBtn.addEventListener('click', async () => {
         const response = await fetch('/api/admin/motd', {


### PR DESCRIPTION
## Summary
- update PayPal settings save handler to reload the store after saving

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685eb418df248333833329c8f18f101a