### PR TITLE
Fix registration checks and show energy timers

### DIFF
--- a/app.py
+++ b/app.py
@@ -254,8 +254,10 @@ def register():
     password = data.get('password', '')
     if not re.match(r'^[^@\s]+@[^@\s]+\.[^@\s]+$', email):
         return jsonify({'success': False, 'message': 'Invalid email format'})
-    if not re.match(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10}$', password):
-        return jsonify({'success': False, 'message': 'Password must be 10 characters with letters and numbers'})
+    if db.email_exists(email):
+        return jsonify({'success': False, 'message': 'Email already registered'})
+    if not re.match(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$', password):
+        return jsonify({'success': False, 'message': 'Password must be at least 10 characters with letters and numbers'})
     result = db.register_user(data.get('username'), email, password)
     if result == "Success":
         send_email(email, "Registration Confirmation",
@@ -334,8 +336,8 @@ def change_password():
         return jsonify({'success': False, 'message': 'Current password incorrect'})
     if new_password != confirm_password:
         return jsonify({'success': False, 'message': 'Passwords do not match'})
-    if not re.match(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10}$', new_password):
-        return jsonify({'success': False, 'message': 'Password must be 10 characters with letters and numbers'})
+    if not re.match(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$', new_password):
+        return jsonify({'success': False, 'message': 'Password must be at least 10 characters with letters and numbers'})
     db.update_user_profile(session['user_id'], password=new_password)
     return jsonify({'success': True})
 
@@ -361,7 +363,11 @@ def get_player_data():
         'collection': player_data['collection'],
         'is_admin': profile.get('is_admin', 0),
         'profile_image': profile.get('profile_image'),
-        'email': profile.get('email')
+        'email': profile.get('email'),
+        'energy_last': player_data.get('energy_last'),
+        'dungeon_last': player_data.get('dungeon_last'),
+        'energy_cap': 10,
+        'dungeon_cap': 5
     }
     return jsonify({'success': True, 'data': full_data})
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -69,9 +69,11 @@
                 <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Gold">
                 <span id="gold-count"></span>
                 <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Energy">
-                <span id="energy-count"></span>
+                <span id="energy-count"></span>/<span id="energy-max">10</span>
+                <span id="energy-timer"></span>
                 <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Dungeon Energy">
-                <span id="dungeon-energy-count"></span>
+                <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
+                <span id="dungeon-timer"></span>
                 <button id="report-bug-button">Report Bug</button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- enforce unique email on registration
- allow passwords of 10 or more characters
- expose energy timer data in `player_data`
- display energy and dungeon timers with caps in UI

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 local_run.py --help` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ec53630588333a24b0a3dce1f8f9b