### PR TITLE
Fix store receipt prompt

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -894,6 +894,7 @@ async function updateStoreDisplay() {
                 }
             }).render(`#paypal-${pkg.id}`);
         } else {
+            div.dataset.requiresReceipt = pkg.amount ? '1' : '0';
             div.innerHTML += `<button class="purchase-btn" data-package-id="${pkg.id}">Buy</button>`;
         }
         storePackagesContainer.appendChild(div);


### PR DESCRIPTION
## Summary
- ensure purchase buttons in the store correctly flag when a receipt is required

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685ecb93534c83338a9c57c826d1594e