### PR TITLE
Add highscores column and admin online view

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1353,3 +1353,13 @@ button:disabled, .fantasy-button:disabled {
     vertical-align: middle;
     margin-right: 4px;
 }
+
+/* Highscore columns */
+.score-columns {
+    display: flex;
+    gap: 20px;
+    justify-content: space-between;
+}
+.score-column {
+    flex: 1;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -107,12 +107,26 @@
 
             <!-- V3: NEW Online Users View -->
             <div id="online-view" class="view">
-                 <div class="section-header">
-                     <h2>Players Online</h2>
-                     <button class="tutorial-btn" data-tutorial="See who is currently playing the game.">?</button>
-                 </div>
-                 <div id="online-list-container" class="online-list"></div>
-                 <div id="all-users-container" class="online-list"></div>
+                <div id="online-section" class="admin-only">
+                    <div class="section-header">
+                        <h2>Players Online</h2>
+                        <button class="tutorial-btn" data-tutorial="See who is currently playing the game.">?</button>
+                    </div>
+                    <div id="online-list-container" class="online-list"></div>
+                </div>
+                <div id="highscores-container" class="online-list">
+                    <h3>Highscores</h3>
+                    <div class="score-columns">
+                        <div class="score-column">
+                            <h4>Tower Progress</h4>
+                            <div id="tower-highscores"></div>
+                        </div>
+                        <div class="score-column">
+                            <h4>Dungeon Runs</h4>
+                            <div id="dungeon-highscores"></div>
+                        </div>
+                    </div>
+                </div>
            </div>
             <!-- Collection View -->
             <div id="collection-view" class="view">


### PR DESCRIPTION
## Summary
- add highscores display with separate tower and dungeon columns
- restrict online players list to admin users
- style highscore columns

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685eccd0652883338c609772b9fab9f6