### PR TITLE
Remove chat join message

### DIFF
--- a/app.py
+++ b/app.py
@@ -891,7 +891,6 @@ def handle_connect():
             'current_stage': progress.get('current_stage', 1),
             'dungeon_runs': progress.get('dungeon_runs', 0)
         }
-        socketio.emit('receive_message', {'username': 'System', 'message': f'{username} has joined the chat.'})
         emit_online_list()
 
 


### PR DESCRIPTION
## Summary
- remove the system message that announces when a user joins the chat

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685ecfd2273c833399d6ca9d37cc5588