### PR TITLE
Add new summon features

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -381,20 +381,29 @@ button:disabled, .fantasy-button:disabled {
     font-size: 24px;
     cursor: pointer;
 }
-
+.summon-buttons {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    margin-bottom: 10px;
+}
 .summon-result-box {
     margin-top: 20px;
     padding: 20px;
-    min-height: 220px; /* Give it a fixed height */
-    width: 200px;      /* Give it a fixed width */
-    display: flex;
+    min-height: 220px;
+    width: 200px;
+    display: none;
     justify-content: center;
     align-items: center;
-
-    /* --- THIS IS THE FIX --- */
-    /* Make it invisible by default */
     background-color: transparent;
     border: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.summon-result-box.show {
+    display: flex;
+    opacity: 1;
 }
 
 /* We also style the card that appears inside it for a better look */
@@ -833,6 +842,19 @@ button:disabled, .fantasy-button:disabled {
     to {
         opacity: 0;
         transform: translate(-50%, -100px);
+    }
+}
+
+.summon-flash {
+    animation: summon-flash 0.5s ease-out;
+}
+
+@keyframes summon-flash {
+    from {
+        box-shadow: 0 0 20px rgba(255, 255, 255, 0.9);
+    }
+    to {
+        box-shadow: none;
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -154,8 +154,13 @@
                         <h2>The Summoning Altar</h2>
                         <button class="tutorial-btn" data-tutorial="Spend gems here to summon additional heroes for your roster.">?</button>
                     </div>
-                    <p>Use 150 Gems to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
-                    <button id="perform-summon-button">Summon</button>
+                    <p>Use <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" class="currency-icon" alt="Gems">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
+                    <div class="summon-buttons">
+                        <button id="perform-summon-button">Summon</button>
+                        <button id="summon-ten-button">Summon x10</button>
+                        <button id="free-summon-button">Daily Free Summon</button>
+                        <span id="free-summon-timer"></span>
+                    </div>
                     <div id="summon-result" class="summon-result-box"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enhance summon page UI with gem icon and extra buttons
- show summon results with animation
- implement free daily summon and x10 summon
- add support on backend for multiple summons and free summon cooldown
- update database schema with `free_last` column

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ed0c78e7c83338e3862707f6ae45b