### PR TITLE
Expand roster for tower battles

### DIFF
--- a/characters.json
+++ b/characters.json
@@ -20,6 +20,16 @@
   { "name": "Kairos, Time Weaver", "rarity": "UR", "element": "Water", "base_hp": 280, "base_atk": 90, "crit_chance": 18, "crit_damage": 2.5, "image_file": "kairos_timeweaver.png" },
   { "name": "Nyx, Eternal Shadow", "rarity": "LR", "element": "Grass", "base_hp": 450, "base_atk": 110, "crit_chance": 25, "crit_damage": 3.0, "image_file": "nyx_shadow.png" },
   { "name": "Helios, Radiant Titan", "rarity": "LR", "element": "Fire", "base_hp": 500, "base_atk": 100, "crit_chance": 20, "crit_damage": 3.5, "image_file": "helios_titan.png" },
-  { "name": "Aurelia, Divine Sorceress", "rarity": "LR", "element": "Water", "base_hp": 420, "base_atk": 120, "crit_chance": 30, "crit_damage": 3.2, "image_file": "aurelia_sorceress.png" }
+  { "name": "Aurelia, Divine Sorceress", "rarity": "LR", "element": "Water", "base_hp": 420, "base_atk": 120, "crit_chance": 30, "crit_damage": 3.2, "image_file": "aurelia_sorceress.png" },
+  { "name": "Arin, Wandering Monk", "rarity": "Common", "element": "Water", "base_hp": 95, "base_atk": 16, "crit_chance": 4, "crit_damage": 1.5, "image_file": "placeholder.png" },
+  { "name": "Tessa, Farmhand Archer", "rarity": "Common", "element": "Grass", "base_hp": 80, "base_atk": 21, "crit_chance": 8, "crit_damage": 1.6, "image_file": "placeholder.png" },
+  { "name": "Drax, Ironclad Sellsword", "rarity": "Rare", "element": "Fire", "base_hp": 150, "base_atk": 27, "crit_chance": 7, "crit_damage": 1.7, "image_file": "placeholder.png" },
+  { "name": "Elion, Arcane Duelist", "rarity": "Rare", "element": "Water", "base_hp": 130, "base_atk": 33, "crit_chance": 12, "crit_damage": 1.8, "image_file": "placeholder.png" },
+  { "name": "Nora, Sky Huntress", "rarity": "SSR", "element": "Grass", "base_hp": 210, "base_atk": 60, "crit_chance": 20, "crit_damage": 2.2, "image_file": "placeholder.png" },
+  { "name": "Magnus, Storm Breaker", "rarity": "SSR", "element": "Fire", "base_hp": 240, "base_atk": 65, "crit_chance": 15, "crit_damage": 2.3, "image_file": "placeholder.png" },
+  { "name": "Sylvie, Dream Seer", "rarity": "UR", "element": "Water", "base_hp": 320, "base_atk": 85, "crit_chance": 18, "crit_damage": 2.6, "image_file": "placeholder.png" },
+  { "name": "Orion, Star Champion", "rarity": "UR", "element": "Grass", "base_hp": 330, "base_atk": 88, "crit_chance": 22, "crit_damage": 2.7, "image_file": "placeholder.png" },
+  { "name": "Zephyr, Wind Paragon", "rarity": "LR", "element": "Grass", "base_hp": 460, "base_atk": 115, "crit_chance": 28, "crit_damage": 3.3, "image_file": "placeholder.png" },
+  { "name": "Pyra, Ember Matriarch", "rarity": "LR", "element": "Fire", "base_hp": 480, "base_atk": 105, "crit_chance": 24, "crit_damage": 3.4, "image_file": "placeholder.png" }
 
 ]

--- a/enemies.json
+++ b/enemies.json
@@ -16,6 +16,16 @@
   { "name": "Infernal Minotaur", "rarity": "SSR", "element": "Fire", "base_hp": 1400, "base_atk": 110, "crit_chance": 18, "crit_damage": 2.6, "image_file": "infernal_minotaur.png" },
   { "name": "Ancient Treant", "rarity": "UR", "element": "Grass", "base_hp": 1800, "base_atk": 130, "crit_chance": 20, "crit_damage": 3.0, "image_file": "ancient_treant.png" },
   { "name": "Storm Leviathan", "rarity": "UR", "element": "Water", "base_hp": 2200, "base_atk": 150, "crit_chance": 25, "crit_damage": 3.2, "image_file": "storm_leviathan.png" },
-  { "name": "Abyssal Overlord", "rarity": "LR", "element": "Fire", "base_hp": 3000, "base_atk": 180, "crit_chance": 30, "crit_damage": 3.5, "image_file": "abyssal_overlord.png" }
+  { "name": "Abyssal Overlord", "rarity": "LR", "element": "Fire", "base_hp": 3000, "base_atk": 180, "crit_chance": 30, "crit_damage": 3.5, "image_file": "abyssal_overlord.png" },
+  { "name": "Skeleton Archer", "rarity": "Common", "element": "Fire", "base_hp": 60, "base_atk": 10, "crit_chance": 6, "crit_damage": 1.4, "image_file": "placeholder.png" },
+  { "name": "Bandit Rogue", "rarity": "Common", "element": "Grass", "base_hp": 75, "base_atk": 14, "crit_chance": 12, "crit_damage": 1.7, "image_file": "placeholder.png" },
+  { "name": "Lizardman Spear", "rarity": "Uncommon", "element": "Fire", "base_hp": 180, "base_atk": 22, "crit_chance": 8, "crit_damage": 1.6, "image_file": "placeholder.png" },
+  { "name": "Stone Guardian", "rarity": "Uncommon", "element": "Grass", "base_hp": 220, "base_atk": 26, "crit_chance": 10, "crit_damage": 1.5, "image_file": "placeholder.png" },
+  { "name": "Blood Elemental", "rarity": "Rare", "element": "Water", "base_hp": 350, "base_atk": 38, "crit_chance": 10, "crit_damage": 1.9, "image_file": "placeholder.png" },
+  { "name": "Bone Hydra", "rarity": "Epic", "element": "Fire", "base_hp": 800, "base_atk": 70, "crit_chance": 18, "crit_damage": 2.4, "image_file": "placeholder.png" },
+  { "name": "Ice Kraken", "rarity": "SSR", "element": "Water", "base_hp": 1300, "base_atk": 105, "crit_chance": 20, "crit_damage": 2.7, "image_file": "placeholder.png" },
+  { "name": "Sand Wyrm", "rarity": "UR", "element": "Grass", "base_hp": 2000, "base_atk": 140, "crit_chance": 24, "crit_damage": 3.1, "image_file": "placeholder.png" },
+  { "name": "Phoenix Lord", "rarity": "UR", "element": "Fire", "base_hp": 2300, "base_atk": 160, "crit_chance": 26, "crit_damage": 3.3, "image_file": "placeholder.png" },
+  { "name": "Celestial Colossus", "rarity": "LR", "element": "Water", "base_hp": 3200, "base_atk": 200, "crit_chance": 35, "crit_damage": 3.8, "image_file": "placeholder.png" }
 
 ]


### PR DESCRIPTION
## Summary
- add ten new hero definitions with placeholder image filenames
- add ten new enemy definitions with placeholder image filenames

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ede7cc5c88333b2dec2a318f61f1b