### PR TITLE
Update currency icons and tutorial button UI

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -907,11 +907,9 @@ button:disabled, .fantasy-button:disabled {
     right: 10px;
     width: 24px;
     height: 24px;
-    border-radius: 50%;
-    background-color: #3498db;
-    color: #fff;
     border: none;
-    font-weight: bold;
+    background: url('/static/images/ui/placeholder_button.png') no-repeat center/contain;
+    text-indent: -9999px;
     cursor: pointer;
 }
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -54,7 +54,7 @@ const equipmentContainer = document.getElementById('equipment-container');
 const storePackagesContainer = document.getElementById('store-packages');
 const userIcon = document.getElementById('user-icon');
 const forgotPasswordLink = document.getElementById('forgot-password-link');
-const currencyIconHtml = '<img src="/static/images/ui/gem_icon.png" class="currency-icon" alt="Currency">';
+const currencyIconHtml = '<img src="/static/images/ui/Platinum_Bars_Icon.png" class="currency-icon" alt="Currency">';
 let profileModal;
 let profileEmailInput;
 let profileCurrentPasswordInput;
@@ -1070,12 +1070,12 @@ function updateCampaignDisplay() {
         if (status === 'farmable') {
             iconPath = '/static/images/ui/stage_node_cleared.png';
             const gemsForRepeat = 15;
-            descriptionHTML = `<p class="stage-reward repeat"><img src="/static/images/ui/gem_icon.png" alt="Gems"> Farm this floor for a small reward.</p>`;
+            descriptionHTML = `<p class="stage-reward repeat"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> Farm this floor for a small reward.</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Fight Again (+${gemsForRepeat} Gems)</button>`;
         } else if (status === 'current') {
             iconPath = '/static/images/ui/stage_node_current.png';
             const gemsForFirstClear = 25 + (Math.floor((stageNum - 1) / 5) * 5);
-            descriptionHTML = `<p class="stage-reward"><img src="/static/images/ui/gem_icon.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
+            descriptionHTML = `<p class="stage-reward"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Challenge Floor</button>`;
         }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,16 +62,16 @@
                 <button id="logout-button">Logout</button>
             </div>
             <div id="currency-info">
-                <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" alt="Gems" title="Earned from events and dungeons. Purchase in the Store and spend at the Summoning Altar.">
+                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Earned from events and dungeons. Purchase in the Store and spend at the Summoning Altar.">
                 <span id="gem-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Platinum" title="Buy with real money in the Store. Used for energy refills and special packs.">
+                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Buy with real money in the Store. Used for energy refills and special packs.">
                 <span id="platinum-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Gold" title="Gained from battles and selling heroes. Spend it to level up heroes and equipment.">
+                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gained from battles and selling heroes. Spend it to level up heroes and equipment.">
                 <span id="gold-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Energy" title="Regenerates over time or with Platinum. Required for Tower battles.">
+                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Regenerates over time or with Platinum. Required for Tower battles.">
                 <span id="energy-count"></span>/<span id="energy-max">10</span>
                 <span id="energy-timer"></span>
-                <img src="{{ url_for('static', filename='images/ui/placeholder_button.png') }}" alt="Dungeon Energy" title="Regenerates over time or with Platinum. Required for Armory expeditions.">
+                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Regenerates over time or with Platinum. Required for Armory expeditions.">
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>
@@ -154,7 +154,7 @@
                         <h2>The Summoning Altar</h2>
                         <button class="tutorial-btn" data-tutorial="Spend gems here to summon additional heroes for your roster.">?</button>
                     </div>
-                    <p>Use <img src="{{ url_for('static', filename='images/ui/gem_icon.png') }}" class="currency-icon" alt="Gems">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
+                    <p>Use <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" class="currency-icon" alt="Gems">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
                     <div class="summon-buttons">
                         <button id="perform-summon-button">Summon</button>
                         <button id="summon-ten-button">Summon x10</button>


### PR DESCRIPTION
## Summary
- use new currency icons in the main HUD and summon screen
- show platinum bars icon in the shop display
- update gem rewards in the Tower UI
- style tutorial buttons with an image instead of a blue circle

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `python local_run.py` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ee4e38d50833381f711d2dd927d78