### PR TITLE
Add tooltips and enlarge currency icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -186,7 +186,7 @@ button:disabled, .fantasy-button:disabled {
     font-weight: bold;
 }
 #currency-info img {
-    height: 30px;
+    height: 40px;
 }
 #logout-button {
     padding: 5px 15px;
@@ -1321,6 +1321,12 @@ button:disabled, .fantasy-button:disabled {
     height: auto;
 }
 
+#hero-image-overlay .modal-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 /* Equipment / hero detail modal enhancements */
 #hero-detail-content {
     display: flex;
@@ -1368,8 +1374,8 @@ button:disabled, .fantasy-button:disabled {
 }
 
 .currency-icon {
-    width: 16px;
-    height: 16px;
+    width: 24px;
+    height: 24px;
     vertical-align: middle;
     margin-right: 4px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,16 +62,16 @@
                 <button id="logout-button">Logout</button>
             </div>
             <div id="currency-info">
-                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Earned from events and dungeons. Purchase in the Store and spend at the Summoning Altar.">
+                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store.">
                 <span id="gem-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Buy with real money in the Store. Used for energy refills and special packs.">
+                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs.">
                 <span id="platinum-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gained from battles and selling heroes. Spend it to level up heroes and equipment.">
+                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.">
                 <span id="gold-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Regenerates over time or with Platinum. Required for Tower battles.">
+                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Energy - Regenerates over time or with Platinum. Required for Tower battles.">
                 <span id="energy-count"></span>/<span id="energy-max">10</span>
                 <span id="energy-timer"></span>
-                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Regenerates over time or with Platinum. Required for Armory expeditions.">
+                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions.">
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>
@@ -154,7 +154,7 @@
                         <h2>The Summoning Altar</h2>
                         <button class="tutorial-btn" data-tutorial="Spend gems here to summon additional heroes for your roster.">?</button>
                     </div>
-                    <p>Use <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" class="currency-icon" alt="Gems">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
+                    <p>Use <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" class="currency-icon" alt="Gems" title="Gems - Spend here to summon new heroes.">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
                     <div class="summon-buttons">
                         <button id="perform-summon-button">Summon</button>
                         <button id="summon-ten-button">Summon x10</button>


### PR DESCRIPTION
## Summary
- enlarge currency icons
- add helpful currency tooltips
- tweak summon view tooltip
- improve hero image modal layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685eefd1454c83338591e9d043327959