### PR TITLE
Add info modals and enlarge icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -186,7 +186,7 @@ button:disabled, .fantasy-button:disabled {
     font-weight: bold;
 }
 #currency-info img {
-    height: 40px;
+    height: 50px;
 }
 #logout-button {
     padding: 5px 15px;
@@ -908,7 +908,7 @@ button:disabled, .fantasy-button:disabled {
     width: 24px;
     height: 24px;
     border: none;
-    background: url('/static/images/ui/placeholder_button.png') no-repeat center/contain;
+    background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiIGZpbGw9IiM0YTkwZTIiLz48cmVjdCB4PSIxMSIgeT0iMTAiIHdpZHRoPSIyIiBoZWlnaHQ9IjciIGZpbGw9IndoaXRlIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSI3IiByPSIxIiBmaWxsPSJ3aGl0ZSIvPjwvc3ZnPg==') no-repeat center/contain;
     text-indent: -9999px;
     cursor: pointer;
 }
@@ -1374,8 +1374,8 @@ button:disabled, .fantasy-button:disabled {
 }
 
 .currency-icon {
-    width: 24px;
-    height: 24px;
+    width: 32px;
+    height: 32px;
     vertical-align: middle;
     margin-right: 4px;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -92,6 +92,11 @@ let forgotEmailInput;
 let forgotSubmitBtn;
 let forgotCancelBtn;
 let forgotError;
+let infoModal;
+let infoText;
+let infoCloseBtn;
+let welcomeModal;
+let welcomeCloseBtn;
 
 function displayMessage(text) {
     if (!messageBox) return;
@@ -229,6 +234,11 @@ function attachEventListeners() {
     forgotSubmitBtn = document.getElementById('forgot-submit-btn');
     forgotCancelBtn = document.getElementById('forgot-cancel-btn');
     forgotError = document.getElementById('forgot-error');
+    infoModal = document.getElementById('info-modal');
+    infoText = document.getElementById('info-text');
+    infoCloseBtn = document.getElementById('info-close-btn');
+    welcomeModal = document.getElementById('welcome-modal');
+    welcomeCloseBtn = document.getElementById('welcome-close-btn');
 
     loginButton.addEventListener('click', handleLogin);
     passwordInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleLogin(); });
@@ -315,6 +325,23 @@ function attachEventListeners() {
             window.open('https://github.com/your_username/your_repo/issues', '_blank');
         });
     }
+
+    if (infoCloseBtn) infoCloseBtn.addEventListener('click', () => {
+        if (infoModal) infoModal.classList.remove('active');
+    });
+
+    if (welcomeCloseBtn) welcomeCloseBtn.addEventListener('click', () => {
+        if (welcomeModal) welcomeModal.classList.remove('active');
+        localStorage.setItem('welcomeShown', 'true');
+    });
+
+    document.querySelectorAll('#currency-info img').forEach(icon => {
+        icon.classList.add('clickable');
+        icon.addEventListener('click', () => {
+            if (infoText) infoText.textContent = icon.getAttribute('title') || '';
+            if (infoModal) infoModal.classList.add('active');
+        });
+    });
 
     if (playerNameDisplay) playerNameDisplay.addEventListener('click', openProfileModal);
     if (userIcon) userIcon.addEventListener('click', openProfileModal);
@@ -676,6 +703,9 @@ async function initializeGame() {
         gameScreen.classList.add('active');
         if (chatContainer) chatContainer.classList.remove('hidden');
         connectSocket();
+        if (!localStorage.getItem('welcomeShown') && welcomeModal) {
+            welcomeModal.classList.add('active');
+        }
     } else {
         loginScreen.classList.add('active');
         gameScreen.classList.remove('active');

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,16 +62,16 @@
                 <button id="logout-button">Logout</button>
             </div>
             <div id="currency-info">
-                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store.">
+                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store." class="clickable">
                 <span id="gem-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs.">
+                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs." class="clickable">
                 <span id="platinum-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.">
+                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment." class="clickable">
                 <span id="gold-count"></span>
-                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Energy - Regenerates over time or with Platinum. Required for Tower battles.">
+                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Energy - Regenerates over time or with Platinum. Required for Tower battles." class="clickable">
                 <span id="energy-count"></span>/<span id="energy-max">10</span>
                 <span id="energy-timer"></span>
-                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions.">
+                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions." class="clickable">
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>
@@ -450,6 +450,23 @@
         <div class="modal-buttons">
             <button id="forgot-submit-btn">Submit</button>
             <button id="forgot-cancel-btn">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="info-modal" class="modal-overlay">
+    <div class="modal-content">
+        <p id="info-text"></p>
+        <button id="info-close-btn">Close</button>
+    </div>
+</div>
+
+<div id="welcome-modal" class="modal-overlay">
+    <div class="modal-content">
+        <h3>Welcome to Aethelgard Chronicles</h3>
+        <p>After the Great Shattering, the Spire of Chaos tore through the sky, unleashing endless horrors. Summon legendary heroines and ascend the tower to seal the rift.</p>
+        <div class="modal-buttons">
+            <button id="welcome-close-btn">Begin</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- make currency icons clickable and show details in a modal
- display help buttons with info icon graphic
- show a one-time welcome modal on first login
- enlarge currency icon sizes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f0477f8c08333ae0cec63104c1842