### PR TITLE
Add live PayPal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains a Flask-based gacha game.
 
 ## PayPal Integration
 
-The store can now process payments via PayPal. Configure your PayPal client ID and secret from the Admin Panel. Once configured, PayPal buttons appear in the store for premium currency purchases.
+The store can now process payments via PayPal. Configure your PayPal client ID and secret from the Admin Panel. Once configured, PayPal buttons appear in the store for premium currency purchases. Admins may switch between **Sandbox** and **Live** mode as needed.
 
 During checkout the client sends a PayPal `order_id` to `/api/paypal_complete`.
 The server verifies the order with PayPal's API and uses `grant_currency()` to credit Platinum to the player.
@@ -31,6 +31,7 @@ The old JavaScript prompt for fake receipts has been removed; real purchases are
 1. Login as an admin user.
 2. Open the **Admin** tab.
 3. Fill in `PayPal Client ID` and `PayPal Secret` fields.
-4. Click **Save PayPal** to apply the settings.
+4. Choose either **Sandbox** or **Live** mode.
+5. Click **Save PayPal** to apply the settings.
 
 These values are stored in the database and used by the server when rendering PayPal buttons.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -71,6 +71,8 @@ let paypalSecretInput;
 let paypalSaveBtn;
 let paypalClientDisplay;
 let paypalSecretDisplay;
+let paypalModeInput;
+let paypalModeDisplay;
 let adminMotdInput;
 let adminMotdSaveBtn;
 let adminEventsText;
@@ -217,6 +219,8 @@ function attachEventListeners() {
     paypalSaveBtn = document.getElementById('admin-paypal-save-btn');
     paypalClientDisplay = document.getElementById('paypal-client-display');
     paypalSecretDisplay = document.getElementById('paypal-secret-display');
+    paypalModeInput = document.getElementById('admin-paypal-mode');
+    paypalModeDisplay = document.getElementById('paypal-mode-display');
     adminMotdInput = document.getElementById('admin-motd-text');
     adminMotdSaveBtn = document.getElementById('admin-motd-save-btn');
     adminEventsText = document.getElementById('admin-events-text');
@@ -406,7 +410,7 @@ function attachEventListeners() {
         const response = await fetch('/api/admin/paypal_config', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ client_id: paypalClientIdInput.value, client_secret: paypalSecretInput.value })
+            body: JSON.stringify({ client_id: paypalClientIdInput.value, client_secret: paypalSecretInput.value, mode: paypalModeInput.value })
         });
         const result = await response.json();
         displayMessage(result.success ? 'PayPal settings saved' : 'Update failed');
@@ -419,7 +423,7 @@ function attachEventListeners() {
         const response = await fetch('/api/admin/paypal_config', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ client_id: '', client_secret: '' })
+            body: JSON.stringify({ client_id: '', client_secret: '', mode: 'sandbox' })
         });
         const result = await response.json();
         displayMessage(result.success ? 'PayPal settings removed' : 'Update failed');
@@ -938,6 +942,8 @@ async function loadPaypalConfig() {
         paypalSecretInput.value = result.config.client_secret || '';
         if (paypalClientDisplay) paypalClientDisplay.textContent = result.config.client_id || '';
         if (paypalSecretDisplay) paypalSecretDisplay.textContent = result.config.client_secret || '';
+        if (paypalModeInput) paypalModeInput.value = result.config.mode || 'sandbox';
+        if (paypalModeDisplay) paypalModeDisplay.textContent = result.config.mode || 'sandbox';
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -277,10 +277,15 @@
                 <hr>
                 <input type="text" id="admin-paypal-client-id" placeholder="PayPal Client ID">
                 <input type="text" id="admin-paypal-secret" placeholder="PayPal Secret">
+                <select id="admin-paypal-mode">
+                    <option value="sandbox">Sandbox</option>
+                    <option value="live">Live</option>
+                </select>
                 <button id="admin-paypal-save-btn">Save PayPal</button>
                 <div id="paypal-display">
                     <p>Client ID: <span id="paypal-client-display"></span></p>
                     <p>Secret: <span id="paypal-secret-display"></span></p>
+                    <p>Mode: <span id="paypal-mode-display"></span></p>
                     <button id="admin-paypal-remove-btn">Remove PayPal</button>
                 </div>
                 <hr>


### PR DESCRIPTION
## Summary
- support storing PayPal mode (sandbox or live) in DB
- allow admins to choose the mode from the admin panel
- verify orders against sandbox or live endpoints accordingly
- document new PayPal mode option

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_685f08ccfa488333aed028bb1acb0f8e