### PR TITLE
Update hero portraits and rename Players section

### DIFF
--- a/characters.json
+++ b/characters.json
@@ -21,15 +21,15 @@
   { "name": "Nyx, Eternal Shadow", "rarity": "LR", "element": "Grass", "base_hp": 450, "base_atk": 110, "crit_chance": 25, "crit_damage": 3.0, "image_file": "nyx_shadow.png" },
   { "name": "Helios, Radiant Titan", "rarity": "LR", "element": "Fire", "base_hp": 500, "base_atk": 100, "crit_chance": 20, "crit_damage": 3.5, "image_file": "helios_titan.png" },
   { "name": "Aurelia, Divine Sorceress", "rarity": "LR", "element": "Water", "base_hp": 420, "base_atk": 120, "crit_chance": 30, "crit_damage": 3.2, "image_file": "aurelia_sorceress.png" },
-  { "name": "Arin, Wandering Monk", "rarity": "Common", "element": "Water", "base_hp": 95, "base_atk": 16, "crit_chance": 4, "crit_damage": 1.5, "image_file": "placeholder.png" },
-  { "name": "Tessa, Farmhand Archer", "rarity": "Common", "element": "Grass", "base_hp": 80, "base_atk": 21, "crit_chance": 8, "crit_damage": 1.6, "image_file": "placeholder.png" },
-  { "name": "Drax, Ironclad Sellsword", "rarity": "Rare", "element": "Fire", "base_hp": 150, "base_atk": 27, "crit_chance": 7, "crit_damage": 1.7, "image_file": "placeholder.png" },
-  { "name": "Elion, Arcane Duelist", "rarity": "Rare", "element": "Water", "base_hp": 130, "base_atk": 33, "crit_chance": 12, "crit_damage": 1.8, "image_file": "placeholder.png" },
-  { "name": "Nora, Sky Huntress", "rarity": "SSR", "element": "Grass", "base_hp": 210, "base_atk": 60, "crit_chance": 20, "crit_damage": 2.2, "image_file": "placeholder.png" },
-  { "name": "Magnus, Storm Breaker", "rarity": "SSR", "element": "Fire", "base_hp": 240, "base_atk": 65, "crit_chance": 15, "crit_damage": 2.3, "image_file": "placeholder.png" },
-  { "name": "Sylvie, Dream Seer", "rarity": "UR", "element": "Water", "base_hp": 320, "base_atk": 85, "crit_chance": 18, "crit_damage": 2.6, "image_file": "placeholder.png" },
-  { "name": "Orion, Star Champion", "rarity": "UR", "element": "Grass", "base_hp": 330, "base_atk": 88, "crit_chance": 22, "crit_damage": 2.7, "image_file": "placeholder.png" },
-  { "name": "Zephyr, Wind Paragon", "rarity": "LR", "element": "Grass", "base_hp": 460, "base_atk": 115, "crit_chance": 28, "crit_damage": 3.3, "image_file": "placeholder.png" },
-  { "name": "Pyra, Ember Matriarch", "rarity": "LR", "element": "Fire", "base_hp": 480, "base_atk": 105, "crit_chance": 24, "crit_damage": 3.4, "image_file": "placeholder.png" }
+  { "name": "Arin, Wandering Monk", "rarity": "Common", "element": "Water", "base_hp": 95, "base_atk": 16, "crit_chance": 4, "crit_damage": 1.5, "image_file": "wandering_monk_arin.png" },
+  { "name": "Tessa, Farmhand Archer", "rarity": "Common", "element": "Grass", "base_hp": 80, "base_atk": 21, "crit_chance": 8, "crit_damage": 1.6, "image_file": "farmhand_archer_tessa.png" },
+  { "name": "Drax, Ironclad Sellsword", "rarity": "Rare", "element": "Fire", "base_hp": 150, "base_atk": 27, "crit_chance": 7, "crit_damage": 1.7, "image_file": "ironclad_sellsword_drax.png" },
+  { "name": "Elion, Arcane Duelist", "rarity": "Rare", "element": "Water", "base_hp": 130, "base_atk": 33, "crit_chance": 12, "crit_damage": 1.8, "image_file": "arcane_duelist_elion.png" },
+  { "name": "Nora, Sky Huntress", "rarity": "SSR", "element": "Grass", "base_hp": 210, "base_atk": 60, "crit_chance": 20, "crit_damage": 2.2, "image_file": "sky_huntress_nora.png" },
+  { "name": "Magnus, Storm Breaker", "rarity": "SSR", "element": "Fire", "base_hp": 240, "base_atk": 65, "crit_chance": 15, "crit_damage": 2.3, "image_file": "storm_breaker_magnus.png" },
+  { "name": "Sylvie, Dream Seer", "rarity": "UR", "element": "Water", "base_hp": 320, "base_atk": 85, "crit_chance": 18, "crit_damage": 2.6, "image_file": "dream_seer_sylvie.png" },
+  { "name": "Orion, Star Champion", "rarity": "UR", "element": "Grass", "base_hp": 330, "base_atk": 88, "crit_chance": 22, "crit_damage": 2.7, "image_file": "star_champion_orion.png" },
+  { "name": "Zephyr, Wind Paragon", "rarity": "LR", "element": "Grass", "base_hp": 460, "base_atk": 115, "crit_chance": 28, "crit_damage": 3.3, "image_file": "wind_paragon_zephyr.png" },
+  { "name": "Pyra, Ember Matriarch", "rarity": "LR", "element": "Fire", "base_hp": 480, "base_atk": 105, "crit_chance": 24, "crit_damage": 3.4, "image_file": "ember_matriarch_pyra.png" }
 
 ]

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@
             <div id="online-view" class="view">
                 <div id="online-section" class="admin-only">
                     <div class="section-header">
-                        <h2>Players Online</h2>
+                        <h2>Players</h2>
                         <button class="tutorial-btn" data-tutorial="See who is currently playing the game.">?</button>
                     </div>
                     <div id="online-list-container" class="online-list"></div>
@@ -306,7 +306,7 @@
             <button class="nav-button" data-view="summon-view">Summon</button>
             <button class="nav-button" data-view="campaign-view">The Tower</button>
             <button class="nav-button" data-view="dungeons-view">The Armory</button>
-            <button class="nav-button" data-view="online-view">Online</button>
+            <button class="nav-button" data-view="online-view">Players</button>
             <button class="nav-button admin-only" data-view="admin-view">Admin</button>
             <button class="nav-button" data-view="store-view">Store</button>
         </div>


### PR DESCRIPTION
## Summary
- use actual hero portraits instead of placeholder.png files
- rename the Online section to Players

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_685f2b45955483339bc6cfd7dae4e2a8