### PR TITLE
Fix login with optional email confirmation

### DIFF
--- a/app.py
+++ b/app.py
@@ -299,18 +299,16 @@ def login():
     data = request.json
     username = data.get('username')
     password = data.get('password')
-    user_id = db.login_user(username, password)
+    user_id, confirmed = db.login_user(username, password)
     if user_id:
         session['logged_in'] = True
         session['username'] = username
         session['user_id'] = user_id
-        return jsonify({'success': True})
+        message = ''
+        if not confirmed:
+            message = 'Please confirm your email to unlock all features.'
+        return jsonify({'success': True, 'message': message})
     else:
-        uid = db.get_user_id(username)
-        if uid and db.verify_user_password(uid, password):
-            profile = db.get_user_profile(uid)
-            if profile.get('email_confirmed') != 1:
-                return jsonify({'success': False, 'message': 'Please confirm your email before logging in.'})
         return jsonify({'success': False, 'message': 'Invalid username or password.'})
 
 

--- a/database.py
+++ b/database.py
@@ -153,19 +153,17 @@ def register_user(username, email, password):
 
 def login_user(username, password):
     conn = get_db_connection()
-    user = conn.execute(
+    row = conn.execute(
         "SELECT id, password, banned, email_confirmed FROM users WHERE username = ?",
         (username,)
     ).fetchone()
     conn.close()
-    if (
-        user
-        and verify_password_hash(user['password'], password)
-        and user['banned'] == 0
-        and user.get('email_confirmed', 0) == 1
-    ):
-        return user['id']
-    return None
+
+    if row and verify_password_hash(row["password"], password) and row["banned"] == 0:
+        # Return the user id along with whether their email is confirmed
+        return row["id"], row["email_confirmed"]
+
+    return None, None
 
 def get_player_data(user_id):
     import time

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -737,10 +737,18 @@ async function fetchPlayerDataAndUpdate() {
 }
 
 async function handleLogin() {
-    const response = await fetch('/api/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ username: usernameInput.value, password: passwordInput.value }) });
+    const response = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: usernameInput.value, password: passwordInput.value })
+    });
     const result = await response.json();
-    if (result.success) await initializeGame();
-    else displayMessage(`Login Failed: ${result.message}`);
+    if (result.success) {
+        await initializeGame();
+        if (result.message) displayMessage(result.message);
+    } else {
+        displayMessage(`Login Failed: ${result.message}`);
+    }
 }
 
 async function handleLogout() {


### PR DESCRIPTION
## Summary
- allow login even if the account email hasn't been confirmed
- return a gentle reminder message when an unconfirmed user logs in
- show any login message in the UI

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685f3304418883339c9e08a4e1368d56