### PR TITLE
Fix icon display issues

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -56,7 +56,8 @@ const equipmentContainer = document.getElementById('equipment-container');
 const storePackagesContainer = document.getElementById('store-packages');
 const userIcon = document.getElementById('user-icon');
 const forgotPasswordLink = document.getElementById('forgot-password-link');
-const currencyIconHtml = '<img src="https://twemoji.maxcdn.com/v/latest/72x72/1f4b0.png" class="currency-icon" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs.">';
+// Use local icon so it always loads even without an internet connection
+const currencyIconHtml = '<img src="/static/images/ui/Platinum_Bars_Icon.png" class="currency-icon" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs.">';
 let profileModal;
 let profileEmailInput;
 let profileCurrentPasswordInput;
@@ -1010,6 +1011,10 @@ async function updateStoreDisplay() {
             text = `${currencyIconHtml} +${pkg.dungeon_energy} Dungeon Runs - ${pkg.platinum_cost} Platinum`;
         }
         div.innerHTML = `<h4>${text}</h4>`;
+        // Append the container before rendering PayPal buttons so the element
+        // exists in the DOM when PayPal queries for it.
+        storePackagesContainer.appendChild(div);
+
         if (pkg.amount) {
             if (clientId && window.paypal) {
                 const btnDiv = document.createElement('div');
@@ -1034,7 +1039,6 @@ async function updateStoreDisplay() {
         } else {
             div.innerHTML += `<button class="purchase-btn" data-package-id="${pkg.id}">Buy</button>`;
         }
-        storePackagesContainer.appendChild(div);
     });
 }
 
@@ -1122,12 +1126,12 @@ function updateCampaignDisplay() {
         if (status === 'farmable') {
             iconPath = '/static/images/ui/stage_node_cleared.png';
             const gemsForRepeat = 15;
-            descriptionHTML = `<p class="stage-reward repeat"><img src="https://twemoji.maxcdn.com/v/latest/72x72/1f48e.png" alt="Gems"> Farm this floor for a small reward.</p>`;
+            descriptionHTML = `<p class="stage-reward repeat"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> Farm this floor for a small reward.</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Fight Again (+${gemsForRepeat} Gems)</button>`;
         } else if (status === 'current') {
             iconPath = '/static/images/ui/stage_node_current.png';
             const gemsForFirstClear = 25 + (Math.floor((stageNum - 1) / 5) * 5);
-            descriptionHTML = `<p class="stage-reward"><img src="https://twemoji.maxcdn.com/v/latest/72x72/1f48e.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
+            descriptionHTML = `<p class="stage-reward"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Challenge Floor</button>`;
         }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,16 +60,16 @@
                 <button id="logout-button">Logout</button>
             </div>
             <div id="currency-info">
-                <img src="https://twemoji.maxcdn.com/v/latest/72x72/1f48e.png" alt="Gems" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store." class="clickable">
+                <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" alt="Gems" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store." class="clickable">
                 <span id="gem-count"></span>
-                <img src="https://twemoji.maxcdn.com/v/latest/72x72/1f4b0.png" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs." class="clickable">
+                <img src="{{ url_for('static', filename='images/ui/Platinum_Bars_Icon.png') }}" alt="Platinum" title="Platinum - Purchased with real money. Use it for energy refills and special packs." class="clickable">
                 <span id="platinum-count"></span>
-                <img src="https://twemoji.maxcdn.com/v/latest/72x72/1fa99.png" alt="Gold" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment." class="clickable">
+                <img src="{{ url_for('static', filename='images/ui/Gold_Coins_Icon.png') }}" alt="Gold" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment." class="clickable">
                 <span id="gold-count"></span>
-                <img src="https://twemoji.maxcdn.com/v/latest/72x72/26a1.png" alt="Energy" title="Energy - Regenerates over time or with Platinum. Required for Tower battles." class="clickable">
+                <img src="{{ url_for('static', filename='images/ui/Energy_Icon.png') }}" alt="Energy" title="Energy - Regenerates over time or with Platinum. Required for Tower battles." class="clickable">
                 <span id="energy-count"></span>/<span id="energy-max">10</span>
                 <span id="energy-timer"></span>
-                <img src="https://twemoji.maxcdn.com/v/latest/72x72/1f4dc.png" alt="Dungeon Energy" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions." class="clickable">
+                <img src="{{ url_for('static', filename='images/ui/Dungeon_Runs_Scroll_Icon.png') }}" alt="Dungeon Energy" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions." class="clickable">
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>
@@ -152,7 +152,7 @@
                         <h2>The Summoning Altar</h2>
                         <button class="tutorial-btn" data-tutorial="Spend gems here to summon additional heroes for your roster.">?</button>
                     </div>
-                    <p>Use <img src="https://twemoji.maxcdn.com/v/latest/72x72/1f48e.png" class="currency-icon" alt="Gems" title="Gems - Spend here to summon new heroes.">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
+                    <p>Use <img src="{{ url_for('static', filename='images/ui/Gems_Icon.png') }}" class="currency-icon" alt="Gems" title="Gems - Spend here to summon new heroes.">150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.</p>
                     <div class="summon-buttons">
                         <button id="perform-summon-button">Summon</button>
                         <button id="summon-ten-button">Summon x10</button>


### PR DESCRIPTION
## Summary
- ensure PayPal buttons render after their containers are attached
- revert to local images for currency and energy icons so they always appear

## Testing
- `python3 -m py_compile app.py database.py balance.py local_run.py`


------
https://chatgpt.com/codex/tasks/task_e_685f3e9e79d4833395d9ba86dbab2c85