### PR TITLE
Add lore info to login screen

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -87,6 +87,28 @@ button:disabled, .fantasy-button:disabled {
 .login-container {
     text-align: center;
 }
+.login-lore-box {
+    max-width: 400px;
+    margin-right: 40px;
+    background-color: rgba(0, 0, 0, 0.5);
+    padding: 20px;
+    border-radius: 10px;
+    border: 1px solid #444;
+    text-align: left;
+}
+.login-lore-box h2 {
+    color: #f1c40f;
+    margin-bottom: 10px;
+}
+.login-lore-box p {
+    line-height: 1.4;
+    margin-bottom: 10px;
+}
+#login-wrapper {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+}
 .form-box {
     background-color: rgba(0, 0, 0, 0.5);
     padding: 30px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,9 +18,25 @@
 
     <!-- This screen shows before the user logs in -->
     <div id="login-screen" class="screen active">
-        <div class="login-container">
-            <img src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">
-            <div class="form-box">
+        <div id="login-wrapper">
+            <div class="login-lore-box">
+                <h2>Welcome to Aethelgard</h2>
+                <p>
+                    After the Great Shattering, the endless Spire of Chaos appeared,
+                    unleashing void-touched horrors. Only the Star-forged Maidens you
+                    summon can survive its corruption. Ascend the tower floor by floor
+                    to seal the rift and save our world.
+                </p>
+                <p>
+                    This is a side project from a couple of humble developers who
+                    wanted a lightweight game to enjoy during breaks. Gather heroes,
+                    climb the tower and compare your progress with other players.
+                </p>
+                <p>Thank you for playing and sharing this journey with us!</p>
+            </div>
+            <div class="login-container">
+                <img src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">
+                <div class="form-box">
                 <input type="text" id="username-input" placeholder="Username">
                 <input type="password" id="password-input" placeholder="Password">
                 <div class="button-group">
@@ -48,6 +64,7 @@
         <!-- ============================== -->
 
             </div>
+        </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- show a short lore introduction beside the login form
- style the new lore box and wrapper

## Testing
- `python3 -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_685f59a9f9b08333b40f3eb190d2c04a