### PR TITLE
Energy regen update and store layout fix

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1388,16 +1388,19 @@ button:disabled, .fantasy-button:disabled {
     border: 1px solid #555;
     padding: 10px;
     margin: 10px 0;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
 }
 .store-package div[id^="paypal-"] {
-    text-align: center;
+    max-width: 160px;
 }
 .store-package .paypal-buttons {
-    transform: scale(0.85);
-    transform-origin: top center;
-    margin: 0 auto;
-    display: inline-block;
+    width: 100%;
+}
+.store-package .package-text {
+    flex: 1;
 }
 .best-value {
     color: gold;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -57,7 +57,7 @@ const storePackagesContainer = document.getElementById('store-packages');
 const userIcon = document.getElementById('user-icon');
 const forgotPasswordLink = document.getElementById('forgot-password-link');
 // Use local icon so it always loads even without an internet connection
-const currencyIconHtml = '<i class="fa-solid fa-diamond currency-icon" title="Platinum - Purchased with real money. Use it for energy refills and special packs."></i>';
+const currencyIconHtml = '<i class="fa-solid fa-diamond currency-icon"></i>';
 let profileModal;
 let profileEmailInput;
 let profileCurrentPasswordInput;
@@ -132,7 +132,7 @@ function updateResourceTimers() {
     const now = Math.floor(Date.now() / 1000);
     if (energyTimerDisplay) {
         if (gameState.energy < gameState.energy_cap) {
-            const next = gameState.energy_last + 3600;
+            const next = gameState.energy_last + 300; // 5 minutes per energy
             const remain = next - now;
             if (remain <= 0) {
                 fetchPlayerDataAndUpdate();
@@ -145,9 +145,8 @@ function updateResourceTimers() {
     }
     if (dungeonTimerDisplay) {
         if (gameState.dungeon_energy < gameState.dungeon_cap) {
-            const last = new Date(gameState.dungeon_last * 1000);
-            const nextReset = Date.UTC(last.getUTCFullYear(), last.getUTCMonth(), last.getUTCDate() + 1) / 1000;
-            const remain = nextReset - now;
+            const next = gameState.dungeon_last + 900; // 15 minutes per energy
+            const remain = next - now;
             if (remain <= 0) {
                 fetchPlayerDataAndUpdate();
             } else {
@@ -340,10 +339,19 @@ function attachEventListeners() {
         localStorage.setItem('welcomeShown', 'true');
     });
 
+    const iconMessages = {
+        'gems-icon': 'Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store.',
+        'platinum-icon': 'Platinum - Purchased with real money. Use it for energy refills and special packs.',
+        'gold-icon': 'Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.',
+        'energy-icon': 'Energy - Regenerates every 5 minutes or with Platinum. Required for Tower battles.',
+        'dungeon-icon': 'Dungeon Energy - Regenerates every 15 minutes or with Platinum. Required for Armory expeditions.'
+    };
+
     document.querySelectorAll('#currency-info .currency-icon').forEach(icon => {
         icon.classList.add('clickable');
         icon.addEventListener('click', () => {
-            if (infoText) infoText.textContent = icon.getAttribute('title') || '';
+            const msg = iconMessages[icon.id] || '';
+            if (infoText) infoText.textContent = msg;
             if (infoModal) infoModal.classList.add('active');
         });
     });
@@ -1010,7 +1018,10 @@ async function updateStoreDisplay() {
         } else if (pkg.dungeon_energy) {
             text = `${currencyIconHtml} +${pkg.dungeon_energy} Dungeon Runs - ${pkg.platinum_cost} Platinum`;
         }
-        div.innerHTML = `<h4>${text}</h4>`;
+        const textSpan = document.createElement('span');
+        textSpan.className = 'package-text';
+        textSpan.innerHTML = text;
+        div.appendChild(textSpan);
         // Append the container before rendering PayPal buttons so the element
         // exists in the DOM when PayPal queries for it.
         storePackagesContainer.appendChild(div);

--- a/templates/index.html
+++ b/templates/index.html
@@ -78,16 +78,16 @@
                 <button id="logout-button">Logout</button>
             </div>
             <div id="currency-info">
-                <i class="fa-solid fa-gem currency-icon clickable" title="Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store."></i>
+                <i id="gems-icon" class="fa-solid fa-gem currency-icon clickable"></i>
                 <span id="gem-count"></span>
-                <i class="fa-solid fa-diamond currency-icon clickable" title="Platinum - Purchased with real money. Use it for energy refills and special packs."></i>
+                <i id="platinum-icon" class="fa-solid fa-diamond currency-icon clickable"></i>
                 <span id="platinum-count"></span>
-                <i class="fa-solid fa-coins currency-icon clickable" title="Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment."></i>
+                <i id="gold-icon" class="fa-solid fa-coins currency-icon clickable"></i>
                 <span id="gold-count"></span>
-                <i class="fa-solid fa-bolt currency-icon clickable" title="Energy - Regenerates over time or with Platinum. Required for Tower battles."></i>
+                <i id="energy-icon" class="fa-solid fa-bolt currency-icon clickable"></i>
                 <span id="energy-count"></span>/<span id="energy-max">10</span>
                 <span id="energy-timer"></span>
-                <i class="fa-solid fa-scroll currency-icon clickable" title="Dungeon Energy - Regenerates over time or with Platinum. Required for Armory expeditions."></i>
+                <i id="dungeon-icon" class="fa-solid fa-scroll currency-icon clickable"></i>
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>


### PR DESCRIPTION
## Summary
- regenerate tower energy every 5 minutes and dungeon energy every 15 minutes
- rework PayPal store layout with flexbox and max-width button
- show currency descriptions via modal using icon IDs

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`
- `node -c static/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_685f5f73e88c8333adf834615cb21ee0