### PR TITLE
Fix email sending and update tower icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ The old JavaScript prompt for fake receipts has been removed; real purchases are
 5. Click **Save PayPal** to apply the settings.
 
 These values are stored in the database and used by the server when rendering PayPal buttons.
+
+## Email Configuration
+
+Admins may configure SMTP credentials from the **Admin Panel**. Enter the host, port, username and password under the Email section and click **Save Email**. If no settings are provided, outgoing emails will be written to `sent_emails.log`.

--- a/app.py
+++ b/app.py
@@ -70,10 +70,29 @@ STORE_PACKAGES = [
     {"id": "energy_dungeon", "dungeon_energy": 5, "platinum_cost": 50}
 ]
 
-# Simple email helper - writes emails to a log file
+# Simple email helper - attempts SMTP then falls back to logging
 def send_email(to_addr, subject, body):
-    with open('sent_emails.log', 'a', encoding='utf-8') as f:
-        f.write(f"TO: {to_addr}\nSUBJECT: {subject}\n{body}\n---\n")
+    """Send an email using SMTP credentials stored in the database."""
+    conf = db.get_email_config()
+    smtp_host = conf.get('host') or os.getenv('SMTP_HOST')
+    smtp_port = int(conf.get('port') or os.getenv('SMTP_PORT') or 587)
+    smtp_user = conf.get('username') or os.getenv('SMTP_USER')
+    smtp_pass = conf.get('password') or os.getenv('SMTP_PASSWORD')
+    from_addr = smtp_user or 'no-reply@towerchronicles.xyz'
+    try:
+        if smtp_host:
+            import smtplib
+            with smtplib.SMTP(smtp_host, smtp_port) as server:
+                server.starttls()
+                if smtp_user and smtp_pass:
+                    server.login(smtp_user, smtp_pass)
+                msg = f"From: {from_addr}\r\nTo: {to_addr}\r\nSubject: {subject}\r\n\r\n{body}"
+                server.sendmail(from_addr, [to_addr], msg)
+    except Exception as e:
+        print(f"Failed to send email: {e}")
+    finally:
+        with open('sent_emails.log', 'a', encoding='utf-8') as f:
+            f.write(f"TO: {to_addr}\nSUBJECT: {subject}\n{body}\n---\n")
 
 # In-memory store for pending password resets {token: (email, new_password)}
 PASSWORD_RESETS = {}
@@ -293,7 +312,7 @@ def register():
             "Confirm Your Registration",
             f"Please confirm your account by visiting: {confirm_link}",
         )
-        return jsonify({'success': True, 'message': 'Registration successful. Please confirm your email.'})
+        return jsonify({'success': True, 'message': 'Registration successful. A confirmation email was sent, but you can log in now.'})
     return jsonify({'success': False, 'message': result})
 
 
@@ -554,6 +573,22 @@ def admin_paypal_config():
         'client_id': conf.get('client_id'),
         'client_secret': conf.get('client_secret')
     })
+    return jsonify({'success': True})
+
+
+@app.route('/api/admin/email_config', methods=['GET', 'POST'])
+def admin_email_config():
+    if not session.get('logged_in') or not db.is_user_admin(session['user_id']):
+        return jsonify({'success': False}), 403
+    if request.method == 'GET':
+        return jsonify({'success': True, 'config': db.get_email_config()})
+    data = request.json or {}
+    db.update_email_config(
+        host=data.get('host'),
+        port=data.get('port'),
+        username=data.get('username'),
+        password=data.get('password')
+    )
     return jsonify({'success': True})
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -305,6 +305,17 @@
                     <button id="admin-paypal-remove-btn">Remove PayPal</button>
                 </div>
                 <hr>
+                <input type="text" id="admin-email-host" placeholder="SMTP Host">
+                <input type="number" id="admin-email-port" placeholder="SMTP Port" value="587">
+                <input type="text" id="admin-email-user" placeholder="SMTP Username">
+                <input type="password" id="admin-email-pass" placeholder="SMTP Password">
+                <button id="admin-email-save-btn">Save Email</button>
+                <div id="email-display">
+                    <p>Host: <span id="email-host-display"></span></p>
+                    <p>User: <span id="email-user-display"></span></p>
+                    <p>Port: <span id="email-port-display"></span></p>
+                </div>
+                <hr>
                 <textarea id="admin-motd-text" placeholder="Message of the Day" rows="3"></textarea>
                 <button id="admin-motd-save-btn">Save MOTD</button>
                 <textarea id="admin-events-text" placeholder="Events text" rows="6"></textarea>


### PR DESCRIPTION
## Summary
- send emails via SMTP if credentials are provided
- tweak registration success message
- use new gem icon on tower floors
- document SMTP environment variables
- manage email settings via admin panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ffe6d79608333b6f0e18fba96fd92