### PR TITLE
Add admin expedition creation and UI tweaks

### DIFF
--- a/app.py
+++ b/app.py
@@ -614,6 +614,24 @@ def admin_update_lore():
         return jsonify({'success': False, 'message': 'Failed to write lore'})
 
 
+@app.route('/api/admin/expedition', methods=['POST'])
+def admin_create_expedition():
+    if not session.get('logged_in') or not db.is_user_admin(session['user_id']):
+        return jsonify({'success': False}), 403
+    data = request.json or {}
+    name = data.get('name', '').strip()
+    enemies = data.get('enemies', [])
+    if not name or not enemies:
+        return jsonify({'success': False, 'message': 'Name and enemies required'}), 400
+    db.create_expedition(name, enemies)
+    return jsonify({'success': True})
+
+
+@app.route('/api/expeditions')
+def list_expeditions():
+    return jsonify({'success': True, 'expeditions': db.get_all_expeditions()})
+
+
 @app.route('/api/summon', methods=['POST'])
 def summon():
     if not session.get('logged_in'): return jsonify({'success': False, 'message': 'Not logged in'}), 401

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -85,6 +85,9 @@ let adminMotdInput;
 let adminMotdSaveBtn;
 let adminEventsText;
 let adminEventsSaveBtn;
+let adminExpeditionNameInput;
+let adminExpeditionEnemiesInput;
+let adminExpeditionCreateBtn;
 let heroImageOverlay;
 let heroImageLarge;
 let messageBox;
@@ -239,6 +242,9 @@ function attachEventListeners() {
     adminMotdSaveBtn = document.getElementById('admin-motd-save-btn');
     adminEventsText = document.getElementById('admin-events-text');
     adminEventsSaveBtn = document.getElementById('admin-events-save-btn');
+    adminExpeditionNameInput = document.getElementById('admin-expedition-name');
+    adminExpeditionEnemiesInput = document.getElementById('admin-expedition-enemies');
+    adminExpeditionCreateBtn = document.getElementById('admin-expedition-create-btn');
     regUsernameInput = document.getElementById('reg-username');
     regEmailInput = document.getElementById('reg-email');
     regPasswordInput = document.getElementById('reg-password');
@@ -487,6 +493,17 @@ function attachEventListeners() {
         });
         const result = await response.json();
         displayMessage(result.success ? 'Events updated' : 'Update failed');
+    });
+    if (adminExpeditionCreateBtn) adminExpeditionCreateBtn.addEventListener('click', async () => {
+        const name = adminExpeditionNameInput.value.trim();
+        const enemies = adminExpeditionEnemiesInput.value.split(',').map(e => e.trim()).filter(e => e);
+        const response = await fetch('/api/admin/expedition', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: name, enemies: enemies })
+        });
+        const result = await response.json();
+        displayMessage(result.success ? 'Expedition created' : result.message || 'Update failed');
     });
 
     const performSummon = async (btn, count = 1, free = false) => {
@@ -1184,12 +1201,12 @@ function updateCampaignDisplay() {
         if (status === 'farmable') {
             iconPath = '/static/images/ui/stage_node_cleared.png';
             const gemsForRepeat = 15;
-            descriptionHTML = `<p class="stage-reward repeat"><img src="/static/images/ui/gem_icon.png" alt="Gems"> Farm this floor for a small reward.</p>`;
+            descriptionHTML = `<p class="stage-reward repeat"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> Farm this floor for a small reward.</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Fight Again (+${gemsForRepeat} Gems)</button>`;
         } else if (status === 'current') {
             iconPath = '/static/images/ui/stage_node_current.png';
             const gemsForFirstClear = 25 + (Math.floor((stageNum - 1) / 5) * 5);
-            descriptionHTML = `<p class="stage-reward"><img src="/static/images/ui/gem_icon.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
+            descriptionHTML = `<p class="stage-reward"><img src="/static/images/ui/Gems_Icon.png" alt="Gems"> First Clear Reward: ${gemsForFirstClear}</p>`;
             buttonHTML = `<button class="fight-button" data-stage-num="${stageNum}">Challenge Floor</button>`;
         }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -157,6 +157,8 @@
                     💧 Water is strong against 🔥 Fire (Water douses Fire).</p>
                     <h3>Combat Basics</h3>
                     <p>ATK and HP come from hero rarity and equipment. Crit Chance triggers stronger attacks that use Crit Damage.</p>
+                    <h3>Merge Rules</h3>
+                    <p>Combine duplicate heroes to raise their rarity. You need 3 Commons or Rares, 4 SSR, and 5 UR copies to merge to the next tier.</p>
                 </div>
                 <div id="collection-container" class="collection-grid">
                     <!-- Heroes will be dynamically inserted here by JavaScript -->
@@ -320,6 +322,11 @@
                 <button id="admin-motd-save-btn">Save MOTD</button>
                 <textarea id="admin-events-text" placeholder="Events text" rows="6"></textarea>
                 <button id="admin-events-save-btn">Save Events</button>
+                <hr>
+                <h3>New Expedition</h3>
+                <input type="text" id="admin-expedition-name" placeholder="Expedition Name">
+                <textarea id="admin-expedition-enemies" placeholder="Enemy names comma separated" rows="2"></textarea>
+                <button id="admin-expedition-create-btn">Create Expedition</button>
             </div>
 
 


### PR DESCRIPTION
## Summary
- add database tables for expeditions and levels
- expose API endpoints to create and list expeditions
- wire up admin UI to create expeditions
- switch Tower gem icon to use new asset
- describe merge rules in the Heroes section

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6860087542a08333830cbddf9b6fbf3f