### PR TITLE
Add admin management for tower levels

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -366,6 +366,13 @@
                 <input type="file" id="admin-item-image">
                 <button id="admin-item-create-btn">Create Item</button>
                 <div id="admin-item-list" class="admin-entity-list"></div>
+
+                <hr>
+                <h3>Manage Tower Levels</h3>
+                <input type="number" id="admin-tower-stage" placeholder="Stage #">
+                <input type="text" id="admin-tower-enemy" placeholder="Enemy Code">
+                <button id="admin-tower-save-btn">Save Level</button>
+                <div id="admin-tower-list" class="admin-entity-list"></div>
             </div>
 
 


### PR DESCRIPTION
## Summary
- support custom tower level data in the database
- expose APIs for admins to list and edit tower levels
- allow admin UI to manage tower levels

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_6862b60a8ac083338b3eae50ff4772b5