### PR TITLE
Improve mobile layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -248,6 +248,11 @@ button:disabled, .fantasy-button:disabled {
     object-fit: cover;
     border-radius: 5px;
 }
+.team-slot h4 {
+    font-size: 14px;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
 
 /* Bottom Navigation Bar */
 #nav-bar {
@@ -1476,4 +1481,34 @@ button:disabled, .fantasy-button:disabled {
 #admin-view textarea,
 #admin-view select {
     width: 95%;
+}
+
+/* --- Mobile & Portrait Adjustments --- */
+@media screen and (max-width: 600px), screen and (orientation: portrait) {
+    body, .screen {
+        height: auto;
+        min-height: 100vh;
+    }
+    #nav-bar {
+        height: 60px;
+    }
+    .nav-button {
+        font-size: 16px;
+    }
+    .team-container {
+        flex-wrap: wrap;
+    }
+    .team-slot {
+        width: 45%;
+        padding: 8px;
+    }
+    .team-slot img {
+        width: 100%;
+        height: auto;
+    }
+    #message-box {
+        bottom: 110px;
+        font-size: 14px;
+        max-width: 90%;
+    }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -434,10 +434,10 @@
     </div>
 
     <!-- CHAT FEATURE -->
-    <div id="chat-container" class="hidden">
+    <div id="chat-container" class="hidden collapsed">
         <div id="chat-header">
             <h3>World Chat</h3>
-            <button id="chat-toggle-btn">▾</button>
+            <button id="chat-toggle-btn">▴</button>
         </div>
         <div id="chat-messages"></div>
         <div id="chat-input-area">


### PR DESCRIPTION
## Summary
- tweak hero card text wrapping
- adjust mobile media query for vertical screens
- minimize world chat by default

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6862bd7b28848333b2efd4c06f413ee7