### PR TITLE
Add timed gem and platinum gifts with notifications

### DIFF
--- a/app.py
+++ b/app.py
@@ -477,6 +477,8 @@ def get_player_data():
         'energy_last': player_data.get('energy_last'),
         'dungeon_last': player_data.get('dungeon_last'),
         'free_last': player_data.get('free_last'),
+        'gem_gift_last': player_data.get('gem_gift_last'),
+        'platinum_last': player_data.get('platinum_last'),
         'energy_cap': 10,
         'dungeon_cap': 5
     }
@@ -941,6 +943,36 @@ def summon():
         save_args['free_last'] = now
     db.save_player_data(user_id, **save_args)
     return jsonify({'success': True, 'characters': characters})
+
+
+@app.route('/api/claim_gem_gift', methods=['POST'])
+def claim_gem_gift():
+    if not session.get('logged_in'):
+        return jsonify({'success': False, 'message': 'Not logged in'}), 401
+    user_id = session['user_id']
+    player_data = db.get_player_data(user_id)
+    now = int(time.time())
+    last = player_data.get('gem_gift_last', 0)
+    if now - last < 1800:
+        return jsonify({'success': False, 'message': 'Gift not ready'})
+    new_gems = player_data['gems'] + 50
+    db.save_player_data(user_id, gems=new_gems, gem_gift_last=now)
+    return jsonify({'success': True, 'gems': new_gems})
+
+
+@app.route('/api/claim_platinum_gift', methods=['POST'])
+def claim_platinum_gift():
+    if not session.get('logged_in'):
+        return jsonify({'success': False, 'message': 'Not logged in'}), 401
+    user_id = session['user_id']
+    player_data = db.get_player_data(user_id)
+    now = int(time.time())
+    last = player_data.get('platinum_last', 0)
+    if now - last < 86400:
+        return jsonify({'success': False, 'message': 'Gift not ready'})
+    new_amt = player_data.get('premium_gems', 0) + 10
+    db.save_player_data(user_id, premium_gems=new_amt, platinum_last=now)
+    return jsonify({'success': True, 'platinum': new_amt})
 
 
 @app.route('/api/stage_info/<int:stage_num>', methods=['GET'])

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -268,6 +268,7 @@ button:disabled, .fantasy-button:disabled {
     background-color: transparent;
     color: #e0e0e0; /* Use the same softer white */
     font-size: 20px; /* Make it a bit bigger and more prominent */
+    position: relative;
 
     /* --- THE FIX --- */
     font-family: 'Consolas', monospace;
@@ -280,6 +281,28 @@ button:disabled, .fantasy-button:disabled {
 }
 .nav-button.active {
     background-color: #444;
+}
+
+.red-dot {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 10px;
+    height: 10px;
+    background: red;
+    border-radius: 50%;
+    display: none;
+}
+
+.daily-gift {
+    text-align: center;
+    margin: 10px 0;
+}
+
+.gift-btn {
+    position: relative;
+    padding: 10px 20px;
+    font-size: 18px;
 }
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -39,6 +39,13 @@ const summonButton = document.getElementById('perform-summon-button');
 const summonTenButton = document.getElementById('summon-ten-button');
 const freeSummonButton = document.getElementById('free-summon-button');
 const freeSummonTimerDisplay = document.getElementById('free-summon-timer');
+const gemGiftButton = document.getElementById('gem-gift-button');
+const gemGiftTimerDisplay = document.getElementById('gem-gift-timer');
+const platinumGiftButton = document.getElementById('platinum-gift-button');
+const platinumGiftTimerDisplay = document.getElementById('platinum-gift-timer');
+const homeNavButton = document.querySelector('.nav-button[data-view="home-view"]');
+const summonNavButton = document.querySelector('.nav-button[data-view="summon-view"]');
+const storeNavButton = document.querySelector('.nav-button[data-view="store-view"]');
 const summonResultContainer = document.getElementById('summon-result');
 const stageListContainer = document.getElementById('stage-list');
 const loreContainer = document.getElementById('lore-text-container');
@@ -181,6 +188,12 @@ function formatDuration(sec) {
     return `${s}s`;
 }
 
+function setRedDot(element, show) {
+    if (!element) return;
+    const dot = element.querySelector('.red-dot');
+    if (dot) dot.style.display = show ? 'block' : 'none';
+}
+
 let resourceTimer;
 
 function updateResourceTimers() {
@@ -217,9 +230,41 @@ function updateResourceTimers() {
         if (now >= nextFree) {
             freeSummonButton.disabled = false;
             freeSummonTimerDisplay.textContent = '';
+            setRedDot(freeSummonButton, true);
+            setRedDot(summonNavButton, true);
         } else {
             freeSummonButton.disabled = true;
             freeSummonTimerDisplay.textContent = formatDuration(nextFree - now);
+            setRedDot(freeSummonButton, false);
+            setRedDot(summonNavButton, false);
+        }
+    }
+    if (gemGiftButton && gemGiftTimerDisplay) {
+        const nextGem = (gameState.gem_gift_last || 0) + 1800;
+        if (now >= nextGem) {
+            gemGiftButton.disabled = false;
+            gemGiftTimerDisplay.textContent = '';
+            setRedDot(gemGiftButton, true);
+            setRedDot(homeNavButton, true);
+        } else {
+            gemGiftButton.disabled = true;
+            gemGiftTimerDisplay.textContent = formatDuration(nextGem - now);
+            setRedDot(gemGiftButton, false);
+            setRedDot(homeNavButton, false);
+        }
+    }
+    if (platinumGiftButton && platinumGiftTimerDisplay) {
+        const nextPlat = (gameState.platinum_last || 0) + 86400;
+        if (now >= nextPlat) {
+            platinumGiftButton.disabled = false;
+            platinumGiftTimerDisplay.textContent = '';
+            setRedDot(platinumGiftButton, true);
+            setRedDot(storeNavButton, true);
+        } else {
+            platinumGiftButton.disabled = true;
+            platinumGiftTimerDisplay.textContent = formatDuration(nextPlat - now);
+            setRedDot(platinumGiftButton, false);
+            setRedDot(storeNavButton, false);
         }
     }
 }
@@ -725,6 +770,8 @@ function attachEventListeners() {
     if (summonButton) summonButton.addEventListener('click', () => performSummon(summonButton, 1, false));
     if (summonTenButton) summonTenButton.addEventListener('click', () => performSummon(summonTenButton, 10, false));
     if (freeSummonButton) freeSummonButton.addEventListener('click', () => performSummon(freeSummonButton, 1, true));
+    if (gemGiftButton) gemGiftButton.addEventListener('click', claimGemGift);
+    if (platinumGiftButton) platinumGiftButton.addEventListener('click', claimPlatinumGift);
 
     chatSendButton.addEventListener('click', sendMessage);
     chatInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') sendMessage(); });
@@ -1191,6 +1238,20 @@ function sendMessage() {
         socket.emit('send_message', { message: chatInput.value });
         chatInput.value = '';
     }
+}
+
+async function claimGemGift() {
+    const resp = await fetch('/api/claim_gem_gift', { method: 'POST' });
+    const result = await resp.json();
+    displayMessage(result.message || (result.success ? 'Gems claimed!' : 'Gift not ready'));
+    if (result.success) await fetchPlayerDataAndUpdate();
+}
+
+async function claimPlatinumGift() {
+    const resp = await fetch('/api/claim_platinum_gift', { method: 'POST' });
+    const result = await resp.json();
+    displayMessage(result.message || (result.success ? 'Platinum claimed!' : 'Gift not ready'));
+    if (result.success) await fetchPlayerDataAndUpdate();
 }
 
 // --- UI UPDATE FUNCTIONS ---

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,14 @@
         <p id="dungeon-run-info">Dungeon Runs: <span id="dungeon-run-count">0</span></p>
         <p id="tower-progress-info">Tower Floor: <span id="tower-floor-count">1</span></p>
     </div>
+    <div class="daily-gift" id="gem-gift">
+        <button id="gem-gift-button" class="gift-btn">Claim 50 Gems<span class="red-dot"></span></button>
+        <span id="gem-gift-timer"></span>
+    </div>
+    <div class="daily-gift" id="platinum-gift">
+        <button id="platinum-gift-button" class="gift-btn">Daily Platinum Chest<span class="red-dot"></span></button>
+        <span id="platinum-gift-timer"></span>
+    </div>
     <!-- ===================================== -->
 
 
@@ -176,7 +184,7 @@
                     <div class="summon-buttons">
                         <button id="perform-summon-button">Summon</button>
                         <button id="summon-ten-button">Summon x10</button>
-                        <button id="free-summon-button">Daily Free Summon</button>
+                        <button id="free-summon-button">Daily Free Summon<span class="red-dot"></span></button>
                         <span id="free-summon-timer"></span>
                     </div>
                     <div id="summon-result" class="summon-result-box"></div>
@@ -380,15 +388,15 @@
 
         <!-- BOTTOM NAVIGATION BAR -->
         <div id="nav-bar">
-            <button class="nav-button" data-view="home-view">Home</button>
+            <button class="nav-button" data-view="home-view">Home<span class="red-dot"></span></button>
             <button class="nav-button" data-view="collection-view">Heroes</button>
             <button class="nav-button" data-view="equipment-view">Equipment</button>
-            <button class="nav-button" data-view="summon-view">Summon</button>
+            <button class="nav-button" data-view="summon-view">Summon<span class="red-dot"></span></button>
             <button class="nav-button" data-view="campaign-view">The Tower</button>
             <button class="nav-button" data-view="dungeons-view">Expeditions</button>
             <button class="nav-button" data-view="online-view">Players</button>
             <button class="nav-button admin-only" data-view="admin-view">Admin</button>
-            <button class="nav-button" data-view="store-view">Store</button>
+            <button class="nav-button" data-view="store-view">Store<span class="red-dot"></span></button>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary
- reward players with 50 gems every 30 minutes and a daily 10 platinum chest
- track new reward timers in the database
- expose APIs to claim the gem and platinum gifts
- show red dot notifications for free summon and new gifts
- add buttons for the gifts on the home screen

## Testing
- `python -m py_compile app.py database.py`


------
https://chatgpt.com/codex/tasks/task_e_686356ff2aa88333a04632a292ebae69