### PR TITLE
Add admin background upload and item grants

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOM fully loaded. V5.5 Finalizing...");
     attachEventListeners();
+    loadBackgrounds();
     initializeGame();
 });
 
@@ -134,6 +135,10 @@ let adminTowerStageInput;
 let adminTowerEnemyInput;
 let adminTowerSaveBtn;
 let adminTowerList;
+let adminGiveItemInput;
+let bgSectionSelect;
+let bgImageInput;
+let bgUploadBtn;
 let heroImageOverlay;
 let heroImageLarge;
 let messageBox;
@@ -353,6 +358,10 @@ function attachEventListeners() {
     adminTowerEnemyInput = document.getElementById('admin-tower-enemy');
     adminTowerSaveBtn = document.getElementById('admin-tower-save-btn');
     adminTowerList = document.getElementById('admin-tower-list');
+    adminGiveItemInput = document.getElementById('admin-item-give');
+    bgSectionSelect = document.getElementById('bg-section-select');
+    bgImageInput = document.getElementById('bg-image-input');
+    bgUploadBtn = document.getElementById('bg-upload-btn');
     newEntityTypeSelect = document.getElementById('admin-entity-type');
     newEntityNameInput = document.getElementById('admin-entity-name');
     newEntityCodeInput = document.getElementById('admin-entity-code');
@@ -546,7 +555,8 @@ function attachEventListeners() {
             platinum: parseInt(document.getElementById('admin-platinum').value) || null,
             gold: parseInt(document.getElementById('admin-gold').value) || null,
             character_name: document.getElementById('admin-character-name').value,
-            character_id: parseInt(document.getElementById('admin-character-name').value)
+            character_id: parseInt(document.getElementById('admin-character-name').value),
+            item_code: adminGiveItemInput ? adminGiveItemInput.value : ''
         };
         const response = await fetch('/api/admin/user_action', {
             method: 'POST',
@@ -732,6 +742,17 @@ function attachEventListeners() {
             adminTowerEnemyInput.value = '';
             loadTowerLevelList();
         }
+    });
+
+    if (bgUploadBtn) bgUploadBtn.addEventListener('click', async () => {
+        if (!bgImageInput.files[0]) return;
+        const form = new FormData();
+        form.append('section', bgSectionSelect.value);
+        form.append('image', bgImageInput.files[0]);
+        const resp = await fetch('/api/admin/background', { method: 'POST', body: form });
+        const result = await resp.json();
+        displayMessage(result.success ? 'Background updated' : result.message || 'Update failed');
+        if (result.success) loadBackgrounds();
     });
 
     const performSummon = async (btn, count = 1, free = false) => {
@@ -1566,6 +1587,20 @@ async function loadTowerLevelList() {
             div.innerHTML = `<span>Stage ${lvl.stage}: ${lvl.enemy_code}</span> <button class="edit-tower" data-stage="${lvl.stage}">Edit</button> <button class="delete-tower" data-stage="${lvl.stage}">Delete</button>`;
             adminTowerList.appendChild(div);
         });
+    }
+}
+
+async function loadBackgrounds() {
+    const resp = await fetch('/api/backgrounds');
+    const data = await resp.json();
+    if (data.success) {
+        for (const [section, file] of Object.entries(data.backgrounds)) {
+            const el = document.getElementById(section);
+            if (el) {
+                el.style.backgroundImage = `url('/static/images/backgrounds/${file}')`;
+                el.style.backgroundSize = 'cover';
+            }
+        }
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -273,12 +273,15 @@
                     <option value="unban">Unban</option>
                     <option value="add_hero">Add Hero</option>
                     <option value="remove_hero">Remove Hero</option>
+                    <option value="give_item">Give Item</option>
+                    <option value="give_item_all">Give Item to All</option>
                 </select>
                 <input type="number" id="admin-gems" placeholder="Gems">
                 <input type="number" id="admin-energy" placeholder="Energy">
                 <input type="number" id="admin-platinum" placeholder="Platinum">
                 <input type="number" id="admin-gold" placeholder="Gold">
                 <input type="text" id="admin-character-name" placeholder="Hero name or ID">
+                <input type="text" id="admin-item-give" placeholder="Item code">
                 <button id="admin-submit-btn">Execute</button>
                 <hr>
                 <input type="text" id="admin-paypal-client-id" placeholder="PayPal Client ID">
@@ -381,6 +384,21 @@
                 <input type="text" id="admin-tower-enemy" placeholder="Enemy Code">
                 <button id="admin-tower-save-btn">Save Level</button>
                 <div id="admin-tower-list" class="admin-entity-list"></div>
+                <hr>
+                <h3>Section Backgrounds</h3>
+                <select id="bg-section-select">
+                    <option value="login-screen">Login</option>
+                    <option value="home-view">Home</option>
+                    <option value="collection-view">Heroes</option>
+                    <option value="equipment-view">Equipment</option>
+                    <option value="summon-view">Summon</option>
+                    <option value="campaign-view">The Tower</option>
+                    <option value="dungeons-view">Expeditions</option>
+                    <option value="online-view">Players</option>
+                    <option value="store-view">Store</option>
+                </select>
+                <input type="file" id="bg-image-input">
+                <button id="bg-upload-btn">Upload</button>
             </div>
 
 


### PR DESCRIPTION
## Summary
- allow admins to grant equipment to a single user or all users
- enable uploading custom background images for each section
- expose endpoints for background management
- update admin UI and client logic

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_686359dc34f08333a50cce2df6d5e1a4