### PR TITLE
Fix admin backgrounds and center section instructions

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -222,6 +222,7 @@ button:disabled, .fantasy-button:disabled {
 }
 .view {
     display: none; /* Hide views by default */
+    min-height: 100%; /* Ensure backgrounds cover full section */
 }
 .view.active {
     display: block; /* Show active view */
@@ -980,12 +981,20 @@ button:disabled, .fantasy-button:disabled {
     justify-content: center;
 }
 
+/* Center headers for equipment, heroes and expeditions */
+#equipment-view .section-header,
+#collection-view .section-header,
+#dungeons-view .section-header {
+    justify-content: center;
+}
+
 .heroes-guide {
     background: rgba(0,0,0,0.4);
     padding: 10px;
     border-radius: 5px;
     margin-bottom: 10px;
     font-size: 14px;
+    text-align: center;
 }
 
 .no-heroes {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1599,6 +1599,8 @@ async function loadBackgrounds() {
             if (el) {
                 el.style.backgroundImage = `url('/static/images/backgrounds/${file}')`;
                 el.style.backgroundSize = 'cover';
+                el.style.backgroundPosition = 'center';
+                el.style.backgroundRepeat = 'no-repeat';
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure view backgrounds fill the entire section
- center headers for equipment, heroes and expeditions
- center text in hero instructions
- position uploaded backgrounds correctly

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`
- `python local_run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68636214395c833393a8f235eea239c8