### PR TITLE
Improve daily reward UX

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1262,17 +1262,29 @@ function sendMessage() {
 }
 
 async function claimGemGift() {
+    const before = gameState.gems || 0;
     const resp = await fetch('/api/claim_gem_gift', { method: 'POST' });
     const result = await resp.json();
-    displayMessage(result.message || (result.success ? 'Gems claimed!' : 'Gift not ready'));
-    if (result.success) await fetchPlayerDataAndUpdate();
+    if (result.success) {
+        const gained = (result.gems || 0) - before;
+        displayMessage(`You received ${gained} Gems! Come back in 30m for more.`);
+        await fetchPlayerDataAndUpdate();
+    } else {
+        displayMessage(result.message || 'Gift not ready');
+    }
 }
 
 async function claimPlatinumGift() {
+    const before = gameState.premium_gems || 0;
     const resp = await fetch('/api/claim_platinum_gift', { method: 'POST' });
     const result = await resp.json();
-    displayMessage(result.message || (result.success ? 'Platinum claimed!' : 'Gift not ready'));
-    if (result.success) await fetchPlayerDataAndUpdate();
+    if (result.success) {
+        const gained = (result.platinum || 0) - before;
+        displayMessage(`You received ${gained} Platinum! Come back in 24h for more.`);
+        await fetchPlayerDataAndUpdate();
+    } else {
+        displayMessage(result.message || 'Gift not ready');
+    }
 }
 
 // --- UI UPDATE FUNCTIONS ---

--- a/templates/index.html
+++ b/templates/index.html
@@ -97,13 +97,13 @@
         <div id="main-content">
             <!-- Home View -->
             <div id="home-view" class="view active">
-                <div class="daily-gift" id="gem-gift">
-                    <button id="gem-gift-button" class="gift-btn">Claim 50 Gems<span class="red-dot"></span></button>
-                    <span id="gem-gift-timer"></span>
-                </div>
                 <div class="section-header">
                     <h2>Your Active Team</h2>
                     <button class="tutorial-btn" data-tutorial="This home screen shows your active team and important progress information.">?</button>
+                </div>
+                <div class="daily-gift" id="gem-gift">
+                    <button id="gem-gift-button" class="gift-btn">Claim 50 Gems<span class="red-dot"></span></button>
+                    <span id="gem-gift-timer"></span>
                 </div>
                 <div id="team-display" class="team-container"></div>
 


### PR DESCRIPTION
## Summary
- move gem claim button below the Home title for consistency with the Store page
- show amount received and next availability when claiming gem or platinum gifts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863656cbc608333b174589f336ea2a3