### PR TITLE
Improve profile and armory UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -346,7 +346,10 @@ def register():
         return jsonify({'success': False, 'message': 'Email already registered'})
     if not re.match(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{10,}$', password):
         return jsonify({'success': False, 'message': 'Password must be at least 10 characters with letters and numbers'})
-    result = db.register_user(data.get('username'), email, password)
+    # Choose a random character portrait as the default profile image
+    available_images = [c.get('image_file') for c in character_definitions if c.get('image_file')]
+    default_image = random.choice(available_images) if available_images else None
+    result = db.register_user(data.get('username'), email, password, profile_image=default_image)
     if result == "Success":
         user_id = db.get_user_id(data.get('username'))
         token = secrets.token_urlsafe(16)

--- a/database.py
+++ b/database.py
@@ -167,7 +167,7 @@ def init_db():
     create_admin_if_missing()
     conn.close()
 
-def register_user(username, email, password):
+def register_user(username, email, password, profile_image=None):
     if not username or not password:
         return "Username and password are required."
     conn = get_db_connection()
@@ -175,8 +175,8 @@ def register_user(username, email, password):
         cursor = conn.cursor()
         hashed_pw = hash_password(password)
         cursor.execute(
-            "INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
-            (username, email, hashed_pw)
+            "INSERT INTO users (username, email, password, profile_image) VALUES (?, ?, ?, ?)",
+            (username, email, hashed_pw, profile_image)
         )
         user_id = cursor.lastrowid
         import time
@@ -410,7 +410,7 @@ def set_player_team(user_id, team_ids):
 def get_all_users_with_runs():
     conn = get_db_connection()
     rows = conn.execute(
-        'SELECT users.username, player_data.current_stage, player_data.dungeon_runs '
+        'SELECT users.username, users.profile_image, player_data.current_stage, player_data.dungeon_runs '
         'FROM users JOIN player_data ON users.id = player_data.user_id '
         'WHERE users.is_admin = 0'
     ).fetchall()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -657,6 +657,15 @@ button:disabled, .fantasy-button:disabled {
     font-size: 18px;
 }
 
+/* small profile image for highscores */
+.score-profile {
+    width: 24px;
+    height: 24px;
+    margin-right: 6px;
+    vertical-align: middle;
+    object-fit: contain;
+}
+
 /* V3: Combat Log with Portraits */
 .log-entry {
     display: flex;
@@ -1470,6 +1479,18 @@ button:disabled, .fantasy-button:disabled {
 /* Center equipment view text */
 #equipment-container p {
     text-align: center;
+}
+
+.empty-armory-message {
+    text-align: center;
+    padding: 20px 0;
+}
+
+.profile-image-label {
+    display: block;
+    margin: 5px 0;
+    font-size: 14px;
+    color: #ccc;
 }
 
 .tos-check {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1244,6 +1244,12 @@ function openProfileModal() {
     profileNewPasswordInput.value = '';
     profileConfirmPasswordInput.value = '';
     profileImageSelect.innerHTML = '';
+    const ph = document.createElement('option');
+    ph.value = '';
+    ph.disabled = true;
+    ph.textContent = 'Select profile character';
+    if (!gameState.profile_image) ph.selected = true;
+    profileImageSelect.appendChild(ph);
     masterCharacterList.forEach(c => {
         const opt = document.createElement('option');
         opt.value = c.image_file;
@@ -1329,7 +1335,7 @@ async function updateEquipmentDisplay() {
     const equipmentDefs = await equipmentDefsResponse.json();
     const statsMap = equipmentDefs.reduce((map, item) => { map[item.name] = item.stat_bonuses; return map; }, {});
     if (result.equipment.length === 0) {
-        equipmentContainer.innerHTML = '<p>Your armory is empty. Farm the Armory to find loot, it is an end game mechanic.</p>';
+        equipmentContainer.innerHTML = '<p class="empty-armory-message">Your armory is empty. Farm the Armory to find loot, it is an end game mechanic.</p>';
         return;
     }
     result.equipment.forEach(item => {
@@ -1382,13 +1388,15 @@ async function updateAllUsers() {
     towerSorted.forEach((u, idx) => {
         const div = document.createElement('div');
         div.className = 'online-list-item';
-        div.textContent = `${idx + 1}. ${u.username} - Floor ${u.current_stage}`;
+        const img = `<img class="score-profile" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
+        div.innerHTML = `${img}${idx + 1}. ${u.username} - Floor ${u.current_stage}`;
         towerScoresContainer.appendChild(div);
     });
     dungeonSorted.forEach((u, idx) => {
         const div = document.createElement('div');
         div.className = 'online-list-item';
-        div.textContent = `${idx + 1}. ${u.username} - Runs ${u.dungeon_runs}`;
+        const img = `<img class="score-profile" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
+        div.innerHTML = `${img}${idx + 1}. ${u.username} - Runs ${u.dungeon_runs}`;
         dungeonScoresContainer.appendChild(div);
     });
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -523,6 +523,7 @@
         <input type="password" id="profile-current-password" placeholder="Current Password">
         <input type="password" id="profile-new-password" placeholder="New Password">
         <input type="password" id="profile-confirm-password" placeholder="Confirm New Password">
+        <label for="profile-image-select" class="profile-image-label">Select Profile Character</label>
         <select id="profile-image-select"></select>
         <p class="tos-link"><a href="/tos" target="_blank">View Terms and Conditions</a></p>
         <div class="modal-buttons">


### PR DESCRIPTION
## Summary
- assign random profile pictures on registration
- allow highscores to display user profile images
- clarify profile picture selection in profile menu
- improve empty armory message styling

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_686366cf08dc83338cfa2903bc7e00bb