### PR TITLE
Add AI translation endpoint and language picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository contains a Flask-based gacha game.
 - **Improved Registration** includes email validation and a password reset flow.
 - **Security Update** now stores passwords hashed and requires acceptance of a Terms of Service during registration.
 - **UI Updates** provide refreshed hero modals and combat log readability.
+- **AI Translation** automatically translates interface text using `/api/translate` and a language picker.
 
 ## PayPal Integration
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ import string
 import secrets
 from balance import generate_enemy, calculate_item_power
 from werkzeug.utils import secure_filename
+from deep_translator import GoogleTranslator
 
 
 def load_all_definitions(file_path):
@@ -325,6 +326,20 @@ def get_lore():
 @app.route('/api/motd')
 def get_motd():
     return jsonify({'success': True, 'motd': db.get_motd()})
+
+
+@app.route('/api/translate', methods=['POST'])
+def translate_text():
+    data = request.json or {}
+    text = data.get('text', '')
+    target = data.get('target', '')
+    if not text or not target:
+        return jsonify({'success': False, 'message': 'text and target required'})
+    try:
+        translated = GoogleTranslator(source='auto', target=target).translate(text)
+        return jsonify({'success': True, 'translation': translated})
+    except Exception as e:
+        return jsonify({'success': False, 'message': str(e)})
 
 
 @app.route('/tos')

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ simple-websocket==1.1.0
 Werkzeug==3.1.3
 wsproto==1.2.0
 paypalrestsdk==1.13.3
+deep-translator==1.11.4

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,6 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOM fully loaded. V5.5 Finalizing...");
     attachEventListeners();
+    if (languageSelect) translatePage(languageSelect.value);
     loadBackgrounds();
     initializeGame();
 });
@@ -20,6 +21,7 @@ const usernameInput = document.getElementById('username-input');
 const passwordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-button');
 const registerButton = document.getElementById('register-button');
+const languageSelect = document.getElementById('language-select');
 const playerNameDisplay = document.getElementById('player-name');
 const gemCountDisplay = document.getElementById('gem-count');
 const goldCountDisplay = document.getElementById('gold-count');
@@ -393,6 +395,12 @@ function attachEventListeners() {
     infoCloseBtn = document.getElementById('info-close-btn');
     welcomeModal = document.getElementById('welcome-modal');
     welcomeCloseBtn = document.getElementById('welcome-close-btn');
+
+    if (languageSelect) {
+        languageSelect.addEventListener('change', () => {
+            translatePage(languageSelect.value);
+        });
+    }
 
     loginButton.addEventListener('click', handleLogin);
     passwordInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleLogin(); });

--- a/static/js/translate.js
+++ b/static/js/translate.js
@@ -1,0 +1,19 @@
+async function translatePage(lang) {
+    const nodes = document.querySelectorAll('[data-i18n]');
+    for (const el of nodes) {
+        if (!el.dataset.orig) {
+            el.dataset.orig = el.textContent;
+        }
+        const resp = await fetch('/api/translate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: el.dataset.orig, target: lang })
+        });
+        const data = await resp.json();
+        if (data.success) {
+            el.textContent = data.translation;
+        }
+    }
+}
+
+window.translatePage = translatePage;

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,20 +19,26 @@
     <!-- This screen shows before the user logs in -->
     <div id="login-screen" class="screen active">
         <div id="login-wrapper">
+            <select id="language-select">
+                <option value="en">English</option>
+                <option value="es">Español</option>
+                <option value="fr">Français</option>
+                <option value="de">Deutsch</option>
+            </select>
             <div class="login-lore-box">
-                <h2>Welcome to Aethelgard</h2>
-                <p>
+                <h2 data-i18n>Welcome to Aethelgard</h2>
+                <p data-i18n>
                     After the Great Shattering, the endless Spire of Chaos appeared,
                     unleashing void-touched horrors. Only the Star-forged Maidens you
                     summon can survive its corruption. Ascend the tower floor by floor
                     to seal the rift and save our world.
                 </p>
-                <p>
+                <p data-i18n>
                     This is a side project from a couple of humble developers who
                     wanted a lightweight game to enjoy during breaks. Gather heroes,
                     climb the tower and compare your progress with other players.
                 </p>
-                <p>Thank you for playing and sharing this journey with us!</p>
+                <p data-i18n>Thank you for playing and sharing this journey with us!</p>
             </div>
             <div class="login-container">
                 <img src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">
@@ -40,10 +46,10 @@
                 <input type="text" id="username-input" placeholder="Username">
                 <input type="password" id="password-input" placeholder="Password">
                 <div class="button-group">
-                    <button id="login-button">Login</button>
-                    <button id="register-button">Register</button>
+                    <button id="login-button" data-i18n>Login</button>
+                    <button id="register-button" data-i18n>Register</button>
                 </div>
-                <a href="#" id="forgot-password-link">Forgot Password?</a>
+                <a href="#" id="forgot-password-link" data-i18n>Forgot Password?</a>
 
         <!-- === NEW VIDEO PLACEHOLDER === -->
         <div class="video-container">
@@ -474,7 +480,8 @@
 
     <div id="message-box"></div>
 
-    <!-- Link to our JavaScript file -->
+    <!-- Language and core scripts -->
+    <script src="{{ url_for('static', filename='js/translate.js') }}"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 
     <!-- ======================================================= -->
@@ -493,8 +500,6 @@
             </div>
         </div>
     </div>
-
-    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 
 <div id="hero-detail-overlay" class="modal-overlay">
     <div id="hero-detail-content" class="modal-content">


### PR DESCRIPTION
## Summary
- add `deep-translator` dependency
- create `/api/translate` route using GoogleTranslator
- add client side helper to translate page text
- include language selector and translation attributes in login page
- hook up translation feature from `app.js`
- document AI translation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6863716e5e5483339953615f86d61961