### PR TITLE
Add admin controls for energy settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -538,8 +538,10 @@ def get_player_data():
         'free_last': player_data.get('free_last'),
         'gem_gift_last': player_data.get('gem_gift_last'),
         'platinum_last': player_data.get('platinum_last'),
-        'energy_cap': 10,
-        'dungeon_cap': 5
+        'energy_cap': player_data.get('energy_cap', 10),
+        'dungeon_cap': player_data.get('dungeon_cap', 5),
+        'energy_regen': player_data.get('energy_regen', 300),
+        'dungeon_regen': player_data.get('dungeon_regen', 900)
     }
     return jsonify({'success': True, 'data': full_data})
 
@@ -742,6 +744,22 @@ def admin_email_config():
         port=data.get('port'),
         username=data.get('username'),
         password=data.get('password')
+    )
+    return jsonify({'success': True})
+
+
+@app.route('/api/admin/game_config', methods=['GET', 'POST'])
+def admin_game_config():
+    if not session.get('logged_in') or not db.is_user_admin(session['user_id']):
+        return jsonify({'success': False}), 403
+    if request.method == 'GET':
+        return jsonify({'success': True, 'config': db.get_game_settings()})
+    data = request.json or {}
+    db.update_game_settings(
+        energy_cap=data.get('energy_cap'),
+        dungeon_cap=data.get('dungeon_cap'),
+        energy_regen=data.get('energy_regen'),
+        dungeon_regen=data.get('dungeon_regen')
     )
     return jsonify({'success': True})
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -214,6 +214,25 @@ button:disabled, .fantasy-button:disabled {
     padding: 5px 15px;
 }
 
+/* Language Flags */
+.language-flags {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    margin-left: 10px;
+}
+
+.language-flag {
+    cursor: pointer;
+    font-size: 22px;
+    user-select: none;
+}
+
+.language-flag.active {
+    outline: 1px solid #fff;
+    border-radius: 3px;
+}
+
 /* Main Content Area */
 #main-content {
     flex-grow: 1; /* Take up remaining space */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1060,6 +1060,12 @@ button:disabled, .fantasy-button:disabled {
     color: #ccc;
 }
 
+.forgot-info {
+    font-size: 14px;
+    margin: 5px 0 10px;
+    color: #ccc;
+}
+
 #intel-start-fight-btn {
     background-color: #c0392b; /* Red for fight */
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,7 +3,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOM fully loaded. V5.5 Finalizing...");
     attachEventListeners();
-    if (languageSelect) translatePage(languageSelect.value);
+    translatePage(currentLanguage);
     loadBackgrounds();
     initializeGame();
 });
@@ -21,7 +21,8 @@ const usernameInput = document.getElementById('username-input');
 const passwordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-button');
 const registerButton = document.getElementById('register-button');
-const languageSelect = document.getElementById('language-select');
+const languageFlags = document.querySelectorAll('.language-flag');
+let currentLanguage = localStorage.getItem('language') || 'en';
 const playerNameDisplay = document.getElementById('player-name');
 const gemCountDisplay = document.getElementById('gem-count');
 const goldCountDisplay = document.getElementById('gold-count');
@@ -208,6 +209,16 @@ function setRedDot(element, show) {
     if (!element) return;
     const dot = element.querySelector('.red-dot');
     if (dot) dot.style.display = show ? 'block' : 'none';
+}
+
+function setActiveLanguageFlag() {
+    if (!languageFlags) return;
+    languageFlags.forEach(f => f.classList.remove('active'));
+    languageFlags.forEach(f => {
+        if (f.dataset.lang === currentLanguage) {
+            f.classList.add('active');
+        }
+    });
 }
 
 let resourceTimer;
@@ -442,10 +453,16 @@ function attachEventListeners() {
     welcomeModal = document.getElementById('welcome-modal');
     welcomeCloseBtn = document.getElementById('welcome-close-btn');
 
-    if (languageSelect) {
-        languageSelect.addEventListener('change', () => {
-            translatePage(languageSelect.value);
+    if (languageFlags) {
+        languageFlags.forEach(flag => {
+            flag.addEventListener('click', () => {
+                currentLanguage = flag.dataset.lang;
+                localStorage.setItem('language', currentLanguage);
+                setActiveLanguageFlag();
+                translatePage(currentLanguage);
+            });
         });
+        setActiveLanguageFlag();
     }
 
     loginButton.addEventListener('click', handleLogin);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -173,6 +173,8 @@ let infoText;
 let infoCloseBtn;
 let welcomeModal;
 let welcomeCloseBtn;
+let screenBackgrounds = {};
+let currentView = 'login-screen';
 
 function displayMessage(text) {
     if (!messageBox) return;
@@ -194,6 +196,15 @@ function formatDetails(obj) {
         const val = typeof v === 'object' && v !== null ? JSON.stringify(v) : v;
         return `${k}: ${val}`;
     }).join(', ');
+}
+
+function applyBodyBackground(section) {
+    const file = screenBackgrounds[section];
+    if (file) {
+        document.body.style.backgroundImage = `url('/static/images/backgrounds/${file}'), url('https://www.transparenttextures.com/patterns/dark-leather.png')`;
+    } else {
+        document.body.style.backgroundImage = `url('/static/images/ui/ui_background.png'), url('https://www.transparenttextures.com/patterns/dark-leather.png')`;
+    }
 }
 
 function formatDuration(sec) {
@@ -901,6 +912,8 @@ function attachEventListeners() {
             const targetViewId = button.dataset.view;
             mainContent.querySelectorAll('.view').forEach(view => view.classList.remove('active'));
             document.getElementById(targetViewId)?.classList.add('active');
+            currentView = targetViewId;
+            applyBodyBackground(currentView);
             if (targetViewId !== 'summon-view') {
                 summonResultContainer.innerHTML = '';
                 summonResultContainer.classList.remove('show');
@@ -1214,6 +1227,8 @@ async function initializeGame() {
     if (loggedIn) {
         loginScreen.classList.remove('active');
         gameScreen.classList.add('active');
+        currentView = 'home-view';
+        applyBodyBackground(currentView);
         if (chatContainer) chatContainer.classList.remove('hidden');
         connectSocket();
         if (!localStorage.getItem('welcomeShown') && welcomeModal) {
@@ -1223,6 +1238,8 @@ async function initializeGame() {
         loginScreen.classList.add('active');
         gameScreen.classList.remove('active');
         if (chatContainer) chatContainer.classList.add('hidden');
+        currentView = 'login-screen';
+        applyBodyBackground(currentView);
     }
 }
 
@@ -1270,6 +1287,8 @@ async function handleLogout() {
     gameState = {};
     loginScreen.classList.add('active');
     gameScreen.classList.remove('active');
+    currentView = 'login-screen';
+    applyBodyBackground(currentView);
     if (chatContainer) chatContainer.classList.add('hidden');
     usernameInput.value = '';
     passwordInput.value = '';
@@ -1738,6 +1757,7 @@ async function loadBackgrounds() {
     const resp = await fetch('/api/backgrounds');
     const data = await resp.json();
     if (data.success) {
+        screenBackgrounds = data.backgrounds || {};
         for (const [section, file] of Object.entries(data.backgrounds)) {
             const el = document.getElementById(section);
             if (el) {
@@ -1747,6 +1767,7 @@ async function loadBackgrounds() {
                 el.style.backgroundRepeat = 'no-repeat';
             }
         }
+        applyBodyBackground(currentView);
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,12 +19,12 @@
     <!-- This screen shows before the user logs in -->
     <div id="login-screen" class="screen active">
         <div id="login-wrapper">
-            <select id="language-select">
-                <option value="en">English</option>
-                <option value="es">Español</option>
-                <option value="fr">Français</option>
-                <option value="de">Deutsch</option>
-            </select>
+            <div id="language-flags">
+                <span class="language-flag" data-lang="en">🇬🇧</span>
+                <span class="language-flag" data-lang="es">🇪🇸</span>
+                <span class="language-flag" data-lang="fr">🇫🇷</span>
+                <span class="language-flag" data-lang="de">🇩🇪</span>
+            </div>
             <div class="login-lore-box">
                 <h2 data-i18n>Welcome to Aethelgard</h2>
                 <p data-i18n>
@@ -82,6 +82,12 @@
                 <img id="user-icon" src="{{ url_for('static', filename='images/ui/placeholder_char.png') }}" alt="User Icon" class="user-icon clickable">
                 <span id="player-name" class="clickable"></span>
                 <button id="logout-button">Logout</button>
+                <div id="language-flags-top" class="language-flags">
+                    <span class="language-flag" data-lang="en">🇬🇧</span>
+                    <span class="language-flag" data-lang="es">🇪🇸</span>
+                    <span class="language-flag" data-lang="fr">🇫🇷</span>
+                    <span class="language-flag" data-lang="de">🇩🇪</span>
+                </div>
             </div>
             <div id="currency-info">
                 <i id="gems-icon" class="fa-solid fa-gem currency-icon clickable"></i>
@@ -543,6 +549,12 @@
         <input type="password" id="profile-confirm-password" placeholder="Confirm New Password">
         <label for="profile-image-select" class="profile-image-label">Select Profile Character</label>
         <select id="profile-image-select"></select>
+        <div id="profile-language-flags">
+            <span class="language-flag" data-lang="en">🇬🇧</span>
+            <span class="language-flag" data-lang="es">🇪🇸</span>
+            <span class="language-flag" data-lang="fr">🇫🇷</span>
+            <span class="language-flag" data-lang="de">🇩🇪</span>
+        </div>
         <p class="tos-link"><a href="/tos" target="_blank">View Terms and Conditions</a></p>
         <div class="modal-buttons">
             <button id="profile-save-btn">Save</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -320,6 +320,19 @@
                 <textarea id="admin-events-text" placeholder="Events text" rows="6"></textarea>
                 <button id="admin-events-save-btn">Save Events</button>
                 <hr>
+                <h3>Game Settings</h3>
+                <input type="number" id="admin-energy-cap" placeholder="Energy Cap">
+                <input type="number" id="admin-dungeon-cap" placeholder="Dungeon Cap">
+                <input type="number" id="admin-energy-regen" placeholder="Energy Regen (sec)">
+                <input type="number" id="admin-dungeon-regen" placeholder="Dungeon Regen (sec)">
+                <button id="admin-game-config-save-btn">Save Settings</button>
+                <div id="game-config-display">
+                    <p>Energy Cap: <span id="display-energy-cap"></span></p>
+                    <p>Dungeon Cap: <span id="display-dungeon-cap"></span></p>
+                    <p>Energy Regen: <span id="display-energy-regen"></span></p>
+                    <p>Dungeon Regen: <span id="display-dungeon-regen"></span></p>
+                </div>
+                <hr>
                 <h3>New Expedition</h3>
                 <p class="expedition-help">Use enemy <strong>codes</strong> separated by commas (e.g. EN001, EN008).<br>
                 Drops follow <code>itemCode:chance</code> pairs (e.g. sword:0.5), and image resolution is <code>widthxheight</code>.</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -587,6 +587,7 @@
 <div id="forgot-password-modal" class="modal-overlay">
     <div class="modal-content">
         <h3>Reset Password</h3>
+        <p class="forgot-info">Enter your email and we'll send you a link to reset your password.</p>
         <input type="email" id="forgot-email" placeholder="Email">
         <div id="forgot-error" class="modal-error"></div>
         <div class="modal-buttons">


### PR DESCRIPTION
## Summary
- allow admin to configure energy/dungeon caps and regen rates
- persist settings in new `game_settings` table
- return settings in player data and use them on the client
- add admin UI to modify energy configuration

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640cce08f88333ab03834ad1dac111