### PR TITLE
Add language flags for quick selection

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -79,6 +79,30 @@ button:disabled, .fantasy-button:disabled {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    position: relative;
+}
+
+#language-flags {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+}
+
+#language-flags .language-flag {
+    background: none;
+    border: none;
+    font-size: 24px;
+    margin-left: 5px;
+    cursor: pointer;
+}
+
+#language-flags .language-flag.selected {
+    outline: 2px solid #f1c40f;
+    border-radius: 4px;
+}
+
+#login-screen #language-select {
+    display: none;
 }
 .game-logo {
     width: 400px;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -3,7 +3,8 @@
 document.addEventListener('DOMContentLoaded', () => {
     console.log("DOM fully loaded. V5.5 Finalizing...");
     attachEventListeners();
-    if (languageSelect) translatePage(languageSelect.value);
+    const savedLang = localStorage.getItem('language') || 'en';
+    setLanguage(savedLang);
     loadBackgrounds();
     initializeGame();
 });
@@ -22,6 +23,7 @@ const passwordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-button');
 const registerButton = document.getElementById('register-button');
 const languageSelect = document.getElementById('language-select');
+const languageFlagButtons = document.querySelectorAll('#language-flags button');
 const playerNameDisplay = document.getElementById('player-name');
 const gemCountDisplay = document.getElementById('gem-count');
 const goldCountDisplay = document.getElementById('gold-count');
@@ -74,6 +76,7 @@ let profileCurrentPasswordInput;
 let profileNewPasswordInput;
 let profileConfirmPasswordInput;
 let profileImageSelect;
+let profileLanguageSelect;
 let profileSaveBtn;
 let profileCancelBtn;
 let adminSubmitBtn;
@@ -199,6 +202,15 @@ function setRedDot(element, show) {
     if (!element) return;
     const dot = element.querySelector('.red-dot');
     if (dot) dot.style.display = show ? 'block' : 'none';
+}
+
+function setLanguage(lang) {
+    localStorage.setItem('language', lang);
+    if (languageSelect) languageSelect.value = lang;
+    languageFlagButtons.forEach(btn => {
+        btn.classList.toggle('selected', btn.dataset.lang === lang);
+    });
+    translatePage(lang);
 }
 
 let resourceTimer;
@@ -345,6 +357,7 @@ function attachEventListeners() {
     profileNewPasswordInput = document.getElementById('profile-new-password');
     profileConfirmPasswordInput = document.getElementById('profile-confirm-password');
     profileImageSelect = document.getElementById('profile-image-select');
+    profileLanguageSelect = document.getElementById('profile-language-select');
     profileSaveBtn = document.getElementById('profile-save-btn');
     profileCancelBtn = document.getElementById('profile-cancel-btn');
     adminSubmitBtn = document.getElementById('admin-submit-btn');
@@ -424,9 +437,13 @@ function attachEventListeners() {
 
     if (languageSelect) {
         languageSelect.addEventListener('change', () => {
-            translatePage(languageSelect.value);
+            setLanguage(languageSelect.value);
         });
     }
+
+    languageFlagButtons.forEach(btn => {
+        btn.addEventListener('click', () => setLanguage(btn.dataset.lang));
+    });
 
     loginButton.addEventListener('click', handleLogin);
     passwordInput.addEventListener('keypress', (e) => { if (e.key === 'Enter') handleLogin(); });
@@ -554,6 +571,9 @@ function attachEventListeners() {
         });
         const result = await response.json();
         if (result.success) {
+            if (profileLanguageSelect) {
+                setLanguage(profileLanguageSelect.value);
+            }
             let passChanged = false;
             if (profileCurrentPasswordInput.value || profileNewPasswordInput.value || profileConfirmPasswordInput.value) {
                 const passResp = await fetch('/api/change_password', {
@@ -1291,6 +1311,9 @@ function openProfileModal() {
         if (gameState.profile_image === c.image_file) opt.selected = true;
         profileImageSelect.appendChild(opt);
     });
+    if (profileLanguageSelect) {
+        profileLanguageSelect.value = localStorage.getItem('language') || 'en';
+    }
     profileModal.classList.add('active');
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,12 +18,20 @@
 
     <!-- This screen shows before the user logs in -->
     <div id="login-screen" class="screen active">
+        <div id="language-flags">
+            <button data-lang="en" class="language-flag">🇺🇸</button>
+            <button data-lang="es" class="language-flag">🇪🇸</button>
+            <button data-lang="pt" class="language-flag">🇧🇷</button>
+            <button data-lang="ja" class="language-flag">🇯🇵</button>
+            <button data-lang="zh" class="language-flag">🇨🇳</button>
+        </div>
         <div id="login-wrapper">
             <select id="language-select">
-                <option value="en">English</option>
-                <option value="es">Español</option>
-                <option value="fr">Français</option>
-                <option value="de">Deutsch</option>
+                <option value="en">🇺🇸 English</option>
+                <option value="es">🇪🇸 Español</option>
+                <option value="pt">🇧🇷 Português</option>
+                <option value="ja">🇯🇵 日本語</option>
+                <option value="zh">🇨🇳 中文</option>
             </select>
             <div class="login-lore-box">
                 <h2 data-i18n>Welcome to Aethelgard</h2>
@@ -530,6 +538,14 @@
         <input type="password" id="profile-confirm-password" placeholder="Confirm New Password">
         <label for="profile-image-select" class="profile-image-label">Select Profile Character</label>
         <select id="profile-image-select"></select>
+        <label for="profile-language-select" class="profile-image-label">Language</label>
+        <select id="profile-language-select">
+            <option value="en">🇺🇸 English</option>
+            <option value="es">🇪🇸 Español</option>
+            <option value="pt">🇧🇷 Português</option>
+            <option value="ja">🇯🇵 日本語</option>
+            <option value="zh">🇨🇳 中文</option>
+        </select>
         <p class="tos-link"><a href="/tos" target="_blank">View Terms and Conditions</a></p>
         <div class="modal-buttons">
             <button id="profile-save-btn">Save</button>


### PR DESCRIPTION
## Summary
- show flag buttons in the top-right of the login screen
- hide the old dropdown and highlight the selected flag
- centralize language switching logic with `setLanguage`
- let profile saving use the new helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68647c252e4c83338e31637595b86170