### PR TITLE
Add dynamic game settings and UI enhancements

### DIFF
--- a/app.py
+++ b/app.py
@@ -538,8 +538,10 @@ def get_player_data():
         'free_last': player_data.get('free_last'),
         'gem_gift_last': player_data.get('gem_gift_last'),
         'platinum_last': player_data.get('platinum_last'),
-        'energy_cap': 10,
-        'dungeon_cap': 5
+        'energy_cap': player_data.get('energy_cap', 10),
+        'dungeon_cap': player_data.get('dungeon_cap', 5),
+        'energy_regen': player_data.get('energy_regen', 300),
+        'dungeon_regen': player_data.get('dungeon_regen', 900)
     }
     return jsonify({'success': True, 'data': full_data})
 
@@ -742,6 +744,22 @@ def admin_email_config():
         port=data.get('port'),
         username=data.get('username'),
         password=data.get('password')
+    )
+    return jsonify({'success': True})
+
+
+@app.route('/api/admin/game_settings', methods=['GET', 'POST'])
+def admin_game_settings():
+    if not session.get('logged_in') or not db.is_user_admin(session['user_id']):
+        return jsonify({'success': False}), 403
+    if request.method == 'GET':
+        return jsonify({'success': True, 'settings': db.get_game_settings()})
+    data = request.json or {}
+    db.update_game_settings(
+        energy_cap=data.get('energy_cap'),
+        dungeon_cap=data.get('dungeon_cap'),
+        energy_regen=data.get('energy_regen'),
+        dungeon_regen=data.get('dungeon_regen')
     )
     return jsonify({'success': True})
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -88,15 +88,14 @@ button:disabled, .fantasy-button:disabled {
     right: 10px;
 }
 
-#language-flags .language-flag {
+.language-flags .language-flag {
     background: none;
     border: none;
     font-size: 24px;
     margin-left: 5px;
     cursor: pointer;
 }
-
-#language-flags .language-flag.selected {
+.language-flags .language-flag.selected {
     outline: 2px solid #f1c40f;
     border-radius: 4px;
 }
@@ -234,6 +233,10 @@ button:disabled, .fantasy-button:disabled {
 #currency-info img {
     height: 50px;
 }
+#top-language-flags {
+    display: flex;
+    align-items: center;
+}
 #logout-button {
     padding: 5px 15px;
 }
@@ -322,6 +325,12 @@ button:disabled, .fantasy-button:disabled {
 .daily-gift {
     text-align: center;
     margin: 10px 0;
+}
+
+.daily-gift img {
+    width: 80px;
+    display: block;
+    margin: 0 auto 5px;
 }
 
 .gift-btn {

--- a/templates/index.html
+++ b/templates/index.html
@@ -105,6 +105,13 @@
                 <span id="dungeon-energy-count"></span>/<span id="dungeon-max">5</span>
                 <span id="dungeon-timer"></span>
             </div>
+            <div id="top-language-flags" class="language-flags">
+                <button data-lang="en" class="language-flag">🇺🇸</button>
+                <button data-lang="es" class="language-flag">🇪🇸</button>
+                <button data-lang="pt" class="language-flag">🇧🇷</button>
+                <button data-lang="ja" class="language-flag">🇯🇵</button>
+                <button data-lang="zh" class="language-flag">🇨🇳</button>
+            </div>
         </div>
 
         <!-- MAIN CONTENT AREA: Views will be dynamically displayed here -->
@@ -116,6 +123,7 @@
                     <button class="tutorial-btn" data-tutorial="This home screen shows your active team and important progress information.">?</button>
                 </div>
                 <div class="daily-gift" id="gem-gift">
+                    <img src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
                     <button id="gem-gift-button" class="gift-btn">Claim 50 Gems<span class="red-dot"></span></button>
                     <span id="gem-gift-timer"></span>
                 </div>
@@ -208,6 +216,7 @@
                     <button class="tutorial-btn" data-tutorial="Purchase Platinum or energy here. Transactions are verified server-side.">?</button>
                 </div>
                 <div class="daily-gift" id="platinum-gift">
+                    <img src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
                     <button id="platinum-gift-button" class="gift-btn">Daily Platinum Chest<span class="red-dot"></span></button>
                     <span id="platinum-gift-timer"></span>
                 </div>
@@ -413,6 +422,14 @@
                 </select>
                 <input type="file" id="bg-image-input">
                 <button id="bg-upload-btn">Upload</button>
+
+                <hr>
+                <h3>Game Settings</h3>
+                <input type="number" id="admin-energy-cap" placeholder="Energy Cap">
+                <input type="number" id="admin-dungeon-cap" placeholder="Dungeon Cap">
+                <input type="number" id="admin-energy-regen" placeholder="Energy Regen (sec)">
+                <input type="number" id="admin-dungeon-regen" placeholder="Dungeon Regen (sec)">
+                <button id="admin-game-save-btn">Save Settings</button>
             </div>
 
 
@@ -539,12 +556,19 @@
         <label for="profile-image-select" class="profile-image-label">Select Profile Character</label>
         <select id="profile-image-select"></select>
         <label for="profile-language-select" class="profile-image-label">Language</label>
-        <select id="profile-language-select">
-            <option value="en">🇺🇸 English</option>
-            <option value="es">🇪🇸 Español</option>
-            <option value="pt">🇧🇷 Português</option>
-            <option value="ja">🇯🇵 日本語</option>
-            <option value="zh">🇨🇳 中文</option>
+        <div id="profile-language-flags" class="language-flags">
+            <button data-lang="en" class="language-flag">🇺🇸</button>
+            <button data-lang="es" class="language-flag">🇪🇸</button>
+            <button data-lang="pt" class="language-flag">🇧🇷</button>
+            <button data-lang="ja" class="language-flag">🇯🇵</button>
+            <button data-lang="zh" class="language-flag">🇨🇳</button>
+        </div>
+        <select id="profile-language-select" style="display:none">
+            <option value="en">en</option>
+            <option value="es">es</option>
+            <option value="pt">pt</option>
+            <option value="ja">ja</option>
+            <option value="zh">zh</option>
         </select>
         <p class="tos-link"><a href="/tos" target="_blank">View Terms and Conditions</a></p>
         <div class="modal-buttons">
@@ -578,6 +602,7 @@
 <div id="forgot-password-modal" class="modal-overlay">
     <div class="modal-content">
         <h3>Reset Password</h3>
+        <p>An email will be sent with instructions to reset your password.</p>
         <input type="email" id="forgot-email" placeholder="Email">
         <div id="forgot-error" class="modal-error"></div>
         <div class="modal-buttons">


### PR DESCRIPTION
## Summary
- create new `game_settings` table and helper functions
- regenerate energy using configurable caps and regen times
- admin endpoint and panel fields to edit game settings
- show language flag buttons globally and in profile modal
- add chest icon to daily gifts and explain reset email
- load per-screen backgrounds and apply to body

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865813e31148333ba273e0b933175c9