### PR TITLE
Fix translations and profile language buttons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -325,6 +325,9 @@ button:disabled, .fantasy-button:disabled {
 .daily-gift {
     text-align: center;
     margin: 10px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .daily-gift img {
@@ -337,6 +340,8 @@ button:disabled, .fantasy-button:disabled {
     position: relative;
     padding: 10px 20px;
     font-size: 18px;
+    display: block;
+    margin: 0 auto;
 }
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -23,7 +23,7 @@ const passwordInput = document.getElementById('password-input');
 const loginButton = document.getElementById('login-button');
 const registerButton = document.getElementById('register-button');
 const languageSelect = document.getElementById('language-select');
-const languageFlagButtons = document.querySelectorAll('.language-flag');
+let languageFlagButtons;
 const playerNameDisplay = document.getElementById('player-name');
 const gemCountDisplay = document.getElementById('gem-count');
 const goldCountDisplay = document.getElementById('gold-count');
@@ -444,6 +444,8 @@ function attachEventListeners() {
     infoCloseBtn = document.getElementById('info-close-btn');
     welcomeModal = document.getElementById('welcome-modal');
     welcomeCloseBtn = document.getElementById('welcome-close-btn');
+
+    languageFlagButtons = document.querySelectorAll('.language-flag');
 
     if (languageSelect) {
         languageSelect.addEventListener('change', () => {
@@ -1794,7 +1796,7 @@ function updateCollectionDisplay() {
         const canMerge = heroCounts[hero.character_name] >= mergeCost;
         const isInTeam = teamDBIds.includes(hero.id);
         const stats = getScaledStats(hero);
-        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level}</div><div class="card-stats">ATK: ${stats.atk} | HP: ${stats.hp}</div><div class="card-stats">Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button><button class="level-up-card-btn" data-hero-id="${hero.id}">Level Up (${100 * hero.level})</button><button class="sell-hero-btn" data-hero-id="${hero.id}">Sell</button></div>`;
+        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level}</div><div class="card-stats">ATK: ${stats.atk} | HP: ${stats.hp}</div><div class="card-stats">Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button><button class="level-up-card-btn" data-hero-id="${hero.id}">Level Up (${100 * hero.level}g)</button><button class="sell-hero-btn" data-hero-id="${hero.id}">Sell</button></div>`;
         if (isInTeam) {
             const indicator = document.createElement('div');
             indicator.className = 'in-team-indicator';

--- a/static/js/translate.js
+++ b/static/js/translate.js
@@ -1,6 +1,22 @@
+function markTranslatable() {
+    const loginNodes = document.querySelectorAll('#login-screen *');
+    const adminView = document.getElementById('admin-view');
+    const gameNodes = document.querySelectorAll('#game-screen *');
+    [...loginNodes, ...gameNodes].forEach(el => {
+        if (adminView && adminView.contains(el)) return;
+        if (!el.children.length && el.textContent.trim()) {
+            el.setAttribute('data-i18n', '');
+            if (!el.dataset.orig) el.dataset.orig = el.textContent;
+        }
+    });
+}
+
 async function translatePage(lang) {
+    markTranslatable();
+    const adminView = document.getElementById('admin-view');
     const nodes = document.querySelectorAll('[data-i18n]');
     for (const el of nodes) {
+        if (adminView && adminView.contains(el)) continue;
         if (!el.dataset.orig) {
             el.dataset.orig = el.textContent;
         }


### PR DESCRIPTION
## Summary
- requery language flag buttons after DOM ready so profile flags work
- exclude admin view while translating and mark text nodes safely
- keep chest alignment and g-suffix for level-ups from last update

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`


------
https://chatgpt.com/codex/tasks/task_e_686585c8e7bc833393db18c7dd594319