### PR TITLE
Fix translation handling and keep language flags visible

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1413,6 +1413,8 @@ function updateUI() {
     updateTopPlayer();
     updateMotd();
     startResourceTimers();
+    const lang = localStorage.getItem('language') || 'en';
+    translatePage(lang);
 }
 
 async function updateEquipmentDisplay() {

--- a/static/js/translate.js
+++ b/static/js/translate.js
@@ -4,6 +4,7 @@ function markTranslatable() {
     const gameNodes = document.querySelectorAll('#game-screen *');
     [...loginNodes, ...gameNodes].forEach(el => {
         if (adminView && adminView.contains(el)) return;
+        if (el.classList.contains('language-flag')) return;
         if (!el.children.length && el.textContent.trim()) {
             el.setAttribute('data-i18n', '');
             if (!el.dataset.orig) el.dataset.orig = el.textContent;


### PR DESCRIPTION
## Summary
- avoid translating flag emoji elements so icons stay visible
- re-run translation after updating UI so dynamic content is translated

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659af3813083338381e74f4faa63a0