### PR TITLE
Fix language flag visibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -94,6 +94,8 @@ button:disabled, .fantasy-button:disabled {
     font-size: 24px;
     margin-left: 5px;
     cursor: pointer;
+    /* Use emoji-capable fonts so the flag icons display correctly */
+    font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji", sans-serif;
 }
 .language-flags .language-flag.selected {
     outline: 2px solid #f1c40f;


### PR DESCRIPTION
## Summary
- ensure emoji fonts render correctly for language buttons

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659d8337a88333b8c49566e6d1d8a7