### PR TITLE
Disable translation API and limit language options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a Flask-based gacha game.
 - **Profile Management** allows players to update their email, change passwords
   and select a profile image.
 - **Admin Panel** lets administrators grant resources, manage PayPal settings,
-  ban or unban users and edit the Message of the Day or event text.
+  ban or unban users and edit the Message of the Day, event text, or bug report link.
 - **Batch Grants** allow admins to distribute gems, gold or energy to every player at once.
 - **Energy System** introduces separate energy for the campaign and dungeons
   which regenerates over time.
@@ -18,7 +18,7 @@ This repository contains a Flask-based gacha game.
 - **Improved Registration** includes email validation and a password reset flow.
 - **Security Update** now stores passwords hashed and requires acceptance of a Terms of Service during registration.
 - **UI Updates** provide refreshed hero modals and combat log readability.
-- **Static Translations** load pre-generated Spanish and Japanese dictionaries so pages are translated without calling `/api/translate`.
+- **Static Translations** use only the bundled Spanish and Japanese dictionaries and never contact external services.
 
 ## PayPal Integration
 

--- a/app.py
+++ b/app.py
@@ -367,6 +367,11 @@ def get_motd():
     return jsonify({'success': True, 'motd': db.get_motd()})
 
 
+@app.route('/api/bug_link')
+def get_bug_link():
+    return jsonify({'success': True, 'url': db.get_bug_link()})
+
+
 
 @app.route('/tos')
 def terms_of_service():
@@ -777,6 +782,15 @@ def admin_update_motd():
         return jsonify({'success': False}), 403
     data = request.json or {}
     db.set_motd(data.get('motd', ''))
+    return jsonify({'success': True})
+
+
+@app.route('/api/admin/bug_link', methods=['POST'])
+def admin_update_bug_link():
+    if not session.get('logged_in') or not db.is_user_admin(session['user_id']):
+        return jsonify({'success': False}), 403
+    data = request.json or {}
+    db.set_bug_link(data.get('url', ''))
     return jsonify({'success': True})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,4 @@ simple-websocket==1.1.0
 Werkzeug==3.1.3
 wsproto==1.2.0
 paypalrestsdk==1.13.3
-deep-translator==1.11.4
 psycopg2-binary==2.9.9

--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -49,6 +49,7 @@
   "Save Email": "Guardar correo",
   "Save MOTD": "Guardar mensaje",
   "Save Events": "Guardar eventos",
+  "Save Bug Link": "Guardar enlace de bug",
   "Create Expedition": "Crear expedición",
   "Create": "Crear",
   "Create Hero/Monster": "Crear héroe/monstruo",

--- a/static/i18n/ja.json
+++ b/static/i18n/ja.json
@@ -49,6 +49,7 @@
   "Save Email": "メール保存",
   "Save MOTD": "MOTD保存",
   "Save Events": "イベント保存",
+  "Save Bug Link": "バグリンク保存",
   "Create Expedition": "遠征作成",
   "Create": "作成",
   "Create Hero/Monster": "ヒーロー/モンスター作成",

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,13 +19,11 @@
     <!-- This screen shows before the user logs in -->
     <div id="login-screen" class="screen active">
         <div id="language-flags">
-            <button data-lang="en" class="language-flag">🇺🇸</button>
             <button data-lang="es" class="language-flag">🇪🇸</button>
             <button data-lang="ja" class="language-flag">🇯🇵</button>
         </div>
         <div id="login-wrapper">
             <select id="language-select">
-                <option value="en">🇺🇸 English</option>
                 <option value="es">🇪🇸 Español</option>
                 <option value="ja">🇯🇵 日本語</option>
             </select>
@@ -102,7 +100,6 @@
                 <span id="dungeon-timer"></span>
             </div>
             <div id="top-language-flags" class="language-flags">
-                <button data-lang="en" class="language-flag">🇺🇸</button>
                 <button data-lang="es" class="language-flag">🇪🇸</button>
                 <button data-lang="ja" class="language-flag">🇯🇵</button>
             </div>
@@ -130,7 +127,7 @@
             Welcome, Rift-Mender! The Spire is particularly volatile today. Good luck on your ascent.
         </p>
         <ul>
-            <li>Found a bug? <a href="https://github.com/your_username/your_repo/issues" target="_blank">Report it here!</a></li>
+            <li>Found a bug? <a id="bug-report-link" href="https://github.com/your_username/your_repo/issues" target="_blank">Report it here!</a></li>
             <li>Top Summoner: <span id="top-player-name">Loading...</span> (Floor <span id="top-player-stage">?</span>)</li>
         </ul>
         <p id="dungeon-run-info">Dungeon Runs: <span id="dungeon-run-count">0</span></p>
@@ -330,6 +327,8 @@
                 <button id="admin-motd-save-btn">Save MOTD</button>
                 <textarea id="admin-events-text" placeholder="Events text" rows="6"></textarea>
                 <button id="admin-events-save-btn">Save Events</button>
+                <input type="text" id="admin-bug-link" placeholder="Bug Report URL">
+                <button id="admin-bug-link-save-btn">Save Bug Link</button>
                 <hr>
                 <h3>New Expedition</h3>
                 <p class="expedition-help">Use enemy <strong>codes</strong> separated by commas (e.g. EN001, EN008).<br>
@@ -551,12 +550,10 @@
         <select id="profile-image-select"></select>
         <label for="profile-language-select" class="profile-image-label">Language</label>
         <div id="profile-language-flags" class="language-flags">
-            <button data-lang="en" class="language-flag">🇺🇸</button>
             <button data-lang="es" class="language-flag">🇪🇸</button>
             <button data-lang="ja" class="language-flag">🇯🇵</button>
         </div>
         <select id="profile-language-select" style="display:none">
-            <option value="en">en</option>
             <option value="es">es</option>
             <option value="ja">ja</option>
         </select>


### PR DESCRIPTION
## Summary
- remove English option from language selectors
- rely solely on static Japanese and Spanish translations
- drop deep-translator dependency
- allow admins to edit the bug report link

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`


------
https://chatgpt.com/codex/tasks/task_e_68682806dfcc8333a52b3e6bb896334a