### PR TITLE
Fix store price refresh

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,6 @@ paypalrestsdk.configure({
     'client_id': paypal_conf.get('client_id'),
     'client_secret': paypal_conf.get('client_secret')
 })
-refresh_store_prices()
 
 # Base URL for links in emails
 BASE_URL = os.getenv('BASE_URL', 'https://towerchronicles.xyz')
@@ -82,6 +81,8 @@ def refresh_store_prices():
     for pkg in STORE_PACKAGES:
         if 'amount' in pkg and pkg['id'] in prices:
             pkg['price'] = prices[pkg['id']]
+
+refresh_store_prices()
 
 # Simple email helper - attempts SMTP then falls back to logging
 def send_email(to_addr, subject, body):


### PR DESCRIPTION
## Summary
- fix NameError when loading app by moving refresh_store_prices call after the function definition

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`

------
https://chatgpt.com/codex/tasks/task_e_68685d820c8483339eb84bd1b135a540