### PR TITLE
Add DB connection logging and PostgreSQL URL fix

### DIFF
--- a/database.py
+++ b/database.py
@@ -62,11 +62,15 @@ def get_db_connection():
     global USING_POSTGRES
     db_url = os.getenv("DATABASE_URL")
     if db_url and psycopg2:
+        if db_url.startswith("postgres://"):
+            db_url = "postgresql://" + db_url[len("postgres://"):]
+        print("Using PostgreSQL database")
         conn = psycopg2.connect(db_url, cursor_factory=RealDictCursor)
         conn.autocommit = True
         USING_POSTGRES = True
         return _PGConnectionWrapper(conn)
 
+    print("Using SQLite database")
     conn = sqlite3.connect(DATABASE_NAME)
     conn.row_factory = sqlite3.Row
     return conn


### PR DESCRIPTION
## Summary
- clarify which database gets used by printing a message from `get_db_connection`
- allow `postgres://` URLs by rewriting them to `postgresql://`

## Testing
- `python -m py_compile database.py`
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68685ece0fc483339f14d0074d62ea5a