### PR TITLE
Fix eventlet initialization and enforce PostgreSQL

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,7 @@
 # app.py (V5.4 - Hardened Stat Calculation)
+import eventlet
+eventlet.monkey_patch()
+
 from flask import Flask, jsonify, render_template, request, session
 from flask_socketio import SocketIO, emit
 import os

--- a/database.py
+++ b/database.py
@@ -59,21 +59,14 @@ class _PGConnectionWrapper:
 
 
 def get_db_connection():
-    global USING_POSTGRES
-    db_url = os.getenv("DATABASE_URL")
-    if db_url and psycopg2:
-        if db_url.startswith("postgres://"):
-            db_url = "postgresql://" + db_url[len("postgres://"):]
-        print("Using PostgreSQL database")
-        conn = psycopg2.connect(db_url, cursor_factory=RealDictCursor)
-        conn.autocommit = True
-        USING_POSTGRES = True
-        return _PGConnectionWrapper(conn)
+    if "DATABASE_URL" in os.environ:
+        print("\ud83d\udcf1 Connecting to PostgreSQL...")
+        import psycopg2
+        from psycopg2.extras import RealDictCursor
+        return psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=RealDictCursor)
+    else:
+        raise RuntimeError("\u274c DATABASE_URL is not set. Cannot fall back to SQLite in production.")
 
-    print("Using SQLite database")
-    conn = sqlite3.connect(DATABASE_NAME)
-    conn.row_factory = sqlite3.Row
-    return conn
 
 def hash_password(password: str) -> str:
     """Hash a password for safe storage."""


### PR DESCRIPTION
## Summary
- initialize eventlet before any other imports
- update database connection logic to require `DATABASE_URL`

## Testing
- `python -m py_compile app.py database.py`

------
https://chatgpt.com/codex/tasks/task_e_686878614ed883339439422811f5b332