### PR TITLE
Fix invalid emoji escape in database connection log

### DIFF
--- a/database.py
+++ b/database.py
@@ -60,7 +60,7 @@ class _PGConnectionWrapper:
 
 def get_db_connection():
     if "DATABASE_URL" in os.environ:
-        print("\ud83d\udcf1 Connecting to PostgreSQL...")
+        print("Connecting to PostgreSQL...")
         import psycopg2
         from psycopg2.extras import RealDictCursor
         return psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=RealDictCursor)


### PR DESCRIPTION
## Summary
- fix `get_db_connection` log string

## Testing
- `python -m py_compile app.py database.py balance.py local_run.py`


------
https://chatgpt.com/codex/tasks/task_e_686879efe5508333b9eba6ac02ea01e8