### PR TITLE
Fix psycopg install failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ simple-websocket==1.1.0
 Werkzeug==3.1.3
 wsproto==1.2.0
 paypalrestsdk==1.13.3
-psycopg[binary]==3.1.18
+psycopg[binary]==3.2.9


### PR DESCRIPTION
## Summary
- update the pinned psycopg-binary version so the wheel exists for Python 3.13

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip download psycopg[binary]==3.2.9 -d /tmp` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68687da1c47883339e504feb6292b0a8