### PR TITLE
Fix Postgres aborted transactions in init_db

### DIFF
--- a/database.py
+++ b/database.py
@@ -64,6 +64,12 @@ class _PGConnectionWrapper:
     def commit(self):
         self._conn.commit()
 
+    def rollback(self):
+        self._conn.rollback()
+
+    def __getattr__(self, attr):
+        return getattr(self._conn, attr)
+
     def close(self):
         self._conn.close()
 


### PR DESCRIPTION
## Summary
- add `rollback` and `__getattr__` to `_PGConnectionWrapper`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686881814b34833387eaf5ffa12afdcc