### PR TITLE
Support multi-level dungeon battles

### DIFF
--- a/database.py
+++ b/database.py
@@ -311,6 +311,7 @@ def init_db():
     # Commit before opening a new connection in create_admin_if_missing
     conn.commit()
     create_admin_if_missing()
+    create_default_expeditions()
     conn.close()
 
 def register_user(username, email, password, profile_image=None):
@@ -758,6 +759,68 @@ def create_admin_if_missing():
             cursor.execute("INSERT INTO player_team (user_id, slot_num, character_db_id) VALUES (?, ?, NULL)", (admin_id, i))
         conn.commit()
     conn.close()
+
+
+def create_default_expeditions():
+    """Seed the database with a handful of starter expeditions."""
+    conn = get_db_connection()
+    count = conn.execute('SELECT COUNT(*) AS c FROM expeditions').fetchone()['c']
+    conn.close()
+    if count:
+        return
+
+    defaults = [
+        {
+            'name': 'Goblin Raid',
+            'levels': ['EN001', 'EN002', 'EN003'],
+            'description': 'A nuisance band of goblins threatens the village.',
+            'drops': 'IT001:100',
+            'image_file': None,
+            'image_res': None,
+        },
+        {
+            'name': 'Bandit Incursion',
+            'levels': ['EN016', 'EN017', 'EN018'],
+            'description': 'Bandits and lizardmen prowl the roads.',
+            'drops': 'IT007:50,IT008:50',
+            'image_file': None,
+            'image_res': None,
+        },
+        {
+            'name': 'Shadow Uprising',
+            'levels': ['EN007', 'EN020', 'EN008'],
+            'description': 'Dark creatures gather in the old ruins.',
+            'drops': 'IT009:40,IT010:40',
+            'image_file': None,
+            'image_res': None,
+        },
+        {
+            'name': "Dragon's Den",
+            'levels': ['EN010', 'EN012', 'EN022'],
+            'description': 'Only the brave dare face these dragons.',
+            'drops': 'IT011:25,IT012:25',
+            'image_file': None,
+            'image_res': None,
+        },
+        {
+            'name': 'Abyssal Rift',
+            'levels': ['EN015', 'EN024', 'EN025'],
+            'description': 'An ancient rift spews legendary foes.',
+            'drops': 'IT005:10,IT006:10',
+            'image_file': None,
+            'image_res': None,
+        },
+    ]
+
+    for exp in defaults:
+        create_expedition(
+            exp['name'],
+            exp['levels'],
+            exp['image_file'],
+            exp['description'],
+            exp['drops'],
+            exp['image_res'],
+        )
 
 def get_user_profile(user_id):
     conn = get_db_connection()

--- a/tests/test_dungeon.py
+++ b/tests/test_dungeon.py
@@ -1,0 +1,96 @@
+import json
+import sys
+import os
+from unittest.mock import patch
+import types
+
+# Stub modules not installed in the test environment
+sys.modules['eventlet'] = types.SimpleNamespace(monkey_patch=lambda: None)
+class DummySocketIO:
+    def __init__(self, app):
+        pass
+    def emit(self, *a, **k):
+        pass
+    def on(self, *a, **k):
+        def decorator(f):
+            return f
+        return decorator
+
+sys.modules['flask_socketio'] = types.SimpleNamespace(SocketIO=DummySocketIO, emit=lambda *a, **k: None)
+sys.modules['paypalrestsdk'] = types.SimpleNamespace(configure=lambda *a, **k: None)
+
+class DummyFlask:
+    def __init__(self, *a, **k):
+        self.config = {}
+    def route(self, *a, **k):
+        def decorator(f):
+            return f
+        return decorator
+
+def jsonify(obj):
+    return obj
+
+request = types.SimpleNamespace(get_json=lambda silent=True: {}, form={}, args={})
+session = {}
+
+def render_template(*a, **k):
+    return ''
+
+sys.modules['flask'] = types.SimpleNamespace(
+    Flask=DummyFlask,
+    jsonify=jsonify,
+    render_template=render_template,
+    request=request,
+    session=session,
+)
+sys.modules['werkzeug.security'] = types.SimpleNamespace(
+    generate_password_hash=lambda p: p,
+    check_password_hash=lambda s, p: s == p,
+)
+sys.modules['werkzeug.utils'] = types.SimpleNamespace(secure_filename=lambda x: x)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import pytest
+
+from app import fight_dungeon, character_definitions, enemy_definitions
+import app as app_module
+import database as db
+
+def sample_team():
+    return [character_definitions[0], character_definitions[1], None, None]
+
+def sample_expedition():
+    return {
+        'id': 1,
+        'levels': [
+            {'level': 1, 'enemy': enemy_definitions[0]['code']},
+            {'level': 2, 'enemy': enemy_definitions[1]['code']},
+        ],
+        'drops': None,
+    }
+
+@patch.object(db, 'get_player_team', side_effect=lambda uid, defs: sample_team())
+@patch.object(db, 'get_player_data', return_value={'dungeon_energy':1,'gold':0,'gems':0,'current_stage':1,'dungeon_runs':0})
+@patch.object(db, 'consume_dungeon_energy')
+@patch.object(db, 'get_expedition', side_effect=lambda eid: sample_expedition())
+@patch.object(db, 'increment_dungeon_runs')
+@patch.object(db, 'save_player_data')
+@patch.object(app_module, 'refresh_online_progress')
+@patch('random.random', return_value=0.5)
+def test_multi_level_expedition(mock_rand, mock_refresh, mock_save, mock_inc, mock_get_exp, mock_consume, mock_player_data, mock_team):
+    app_module.request.get_json = lambda silent=True: {'expedition_id': 1}
+    app_module.request.form = {}
+    app_module.request.args = {}
+    app_module.session.clear()
+    app_module.session['logged_in'] = True
+    app_module.session['user_id'] = 1
+    resp = fight_dungeon()
+    data = resp if isinstance(resp, dict) else resp[0]
+    assert data['success'] is True
+    assert data['victory'] is True
+    starts = [e for e in data['log'] if e['type']=='start']
+    assert len(starts) == 2
+    summary = [e for e in data['log'] if e['type']=='summary']
+    assert summary and 'Cleared 2/2 levels.' in summary[0]['message']
+    assert data['gold_won'] == 200

--- a/tests/test_expeditions.py
+++ b/tests/test_expeditions.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import types
+
+# Stub werkzeug security for environments without the library
+sys.modules['werkzeug.security'] = types.SimpleNamespace(
+    generate_password_hash=lambda p: p,
+    check_password_hash=lambda s, p: s == p,
+)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import database as db
+
+
+def test_default_expeditions_created(tmp_path, monkeypatch):
+    monkeypatch.setattr(db, 'DATABASE_NAME', str(tmp_path / 'expeditions.db'), raising=False)
+    monkeypatch.setattr(db, 'USING_POSTGRES', False, raising=False)
+    db.init_db()
+    exps = db.get_all_expeditions()
+    names = [e['name'] for e in exps]
+    assert len(exps) == 5
+    assert names[0] == 'Goblin Raid'
+    assert names[-1] == 'Abyssal Rift'


### PR DESCRIPTION
## Summary
- iterate through multiple expedition levels during dungeon fights
- keep team HP between levels and add summary logging
- test multi-level dungeon fights
- seed database with 5 starter expeditions
- test default expedition seeding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869b0cb25148333b4f1ff17978d1ad0