### PR TITLE
Fix expedition list layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1155,6 +1155,13 @@ button:disabled, .fantasy-button:disabled {
     align-items: center; /* Vertically align the content */
 }
 
+/* Ensure expedition entries stack vertically */
+#expedition-list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 /* Column 1: Image */
 .dungeon-image-container {
     flex-basis: 40%; /* The image column takes up 40% of the space */

--- a/templates/index.html
+++ b/templates/index.html
@@ -270,7 +270,7 @@
     </div>
     <p class="view-description">Embark on dangerous hunts for powerful rewards.</p>
 
-    <div id="expedition-list" class="collection-grid"></div>
+    <div id="expedition-list"></div>
 </div>
 
             <!-- Events View -->


### PR DESCRIPTION
## Summary
- remove grid styling from expedition list so entries don't overlap
- stack expedition entries vertically using flexbox

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e61455448333a69a12ef6a9db448