### PR TITLE
Implement expedition ordering and UI fixes

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -341,7 +341,7 @@ button:disabled, .fantasy-button:disabled {
 /* Chat Container */
 #chat-container {
     position: fixed;
-    bottom: 90px; /* Above the nav bar */
+    bottom: 120px; /* Above the nav bar */
     right: 20px;
     width: 350px;
     height: 400px;

--- a/static/js/translate.js
+++ b/static/js/translate.js
@@ -21,6 +21,8 @@ function markTranslatable() {
 const translationsCache = {};
 
 async function loadTranslations(lang) {
+    lang = (lang || '').toLowerCase();
+    if (lang === 'jp' || lang === 'ja-jp') lang = 'ja';
     if (lang === 'en') return null;
     if (translationsCache[lang]) return translationsCache[lang];
     try {


### PR DESCRIPTION
## Summary
- add `sort_order` to expeditions with database migrations
- support moving expeditions up or down via new API and admin UI buttons
- enrich expedition display with item names and hide image resolution
- normalize Japanese language codes
- raise world chat above the bottom menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aca7415f48333a8ec2060732dc34f