### PR TITLE
Improve hero and item info

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ Admins may configure SMTP credentials from the **Admin Panel**. Enter the host, 
 ## Database Configuration
 
 The application can use either the bundled SQLite file or a PostgreSQL database. To connect to PostgreSQL set the `DATABASE_URL` environment variable to your connection string before starting the app. When `DATABASE_URL` is present the code connects using `psycopg2`; otherwise it falls back to `database.db`.
+
+## Image Optimization
+
+A helper script at `scripts/optimize_images.py` reduces PNG file size using Pillow. Run `python scripts/optimize_images.py` to compress the images under `static/images`. This helps keep memory usage low in production.

--- a/scripts/optimize_images.py
+++ b/scripts/optimize_images.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from PIL import Image
+
+IMAGE_DIRS = [
+    Path('static/images/characters'),
+    Path('static/images/items'),
+    Path('static/images/ui'),
+    Path('static/images/enemies'),
+]
+
+def optimize(p):
+    try:
+        img = Image.open(p)
+    except Exception:
+        return
+    if img.format != 'PNG':
+        return
+    img.save(p, optimize=True)
+
+
+def main():
+    for d in IMAGE_DIRS:
+        for path in d.glob('*'):
+            if path.is_file():
+                optimize(path)
+
+if __name__ == '__main__':
+    main()

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -918,7 +918,7 @@ function attachEventListeners() {
             summonResultContainer.innerHTML = '';
             characters.forEach(character => {
                 const element = character.element || 'None';
-                summonResultContainer.innerHTML += `<div class="team-slot"><div class="card-header"><div class="card-rarity rarity-${character.rarity.toLowerCase()}">[${character.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img src="/static/images/characters/${character.image_file}" alt="${character.name}"><h4>${character.name}</h4><p>ATK: ${character.base_atk} | HP: ${character.base_hp}</p><p>Crit: ${character.crit_chance}% | Crit DMG: ${character.crit_damage}x</p></div>`;
+                summonResultContainer.innerHTML += `<div class="team-slot"><div class="card-header"><div class="card-rarity rarity-${character.rarity.toLowerCase()}">[${character.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img loading="lazy" src="/static/images/characters/${character.image_file}" alt="${character.name}"><h4>${character.name}</h4><p>ATK: ${character.base_atk} | HP: ${character.base_hp}</p><p>Crit: ${character.crit_chance}% | Crit DMG: ${character.crit_damage}x</p></div>`;
             });
             summonResultContainer.classList.add('show');
             await fetchPlayerDataAndUpdate();
@@ -1125,7 +1125,7 @@ function attachEventListeners() {
                 const element = enemy.element || 'None';
                 const cost = result.energy_cost;
                 const gold = result.gold_reward;
-                document.getElementById('intel-enemy-info').innerHTML = `<div class="team-slot"><div class="card-header"><div class="card-rarity">Enemy</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img src="/static/images/${enemy.image_file}" alt="${enemy.name}"><h4>${enemy.name}</h4><div class="card-stats">HP: ~${enemy.hp} | ATK: ~${enemy.atk}</div><p>Energy Cost: ${cost} | Gold: ${gold}</p></div>`;
+                document.getElementById('intel-enemy-info').innerHTML = `<div class="team-slot"><div class="card-header"><div class="card-rarity">Enemy</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img loading="lazy" src="/static/images/${enemy.image_file}" alt="${enemy.name}"><h4>${enemy.name}</h4><div class="card-stats">HP: ~${enemy.hp} | ATK: ~${enemy.atk}</div><p>Energy Cost: ${cost} | Gold: ${gold}</p></div>`;
                 document.getElementById('intel-modal-overlay').classList.add('active');
             } else { displayMessage(`Error: ${result.message}`); }
         }
@@ -1376,11 +1376,14 @@ async function openHeroDetailModal(hero) {
     const charDef = masterCharacterList.find(c => c.name === fullHeroData.character_name) || {};
     const equippedItems = allPlayerItems.filter(item => item.is_equipped_on === fullHeroData.id);
     const stats = getScaledStats(fullHeroData);
+    const sellBase = { 'Common': 50, 'Rare': 150, 'SSR': 400, 'UR': 800, 'LR': 1500 };
+    const sellPrice = (sellBase[fullHeroData.rarity] || 50) * fullHeroData.level;
     let html = `
-        <img class="hero-detail-portrait" src="/static/images/characters/${charDef.image_file || 'placeholder_char.png'}" alt="${fullHeroData.character_name}">
+        <img class="hero-detail-portrait" loading="lazy" src="/static/images/characters/${charDef.image_file || 'placeholder_char.png'}" alt="${fullHeroData.character_name}">
         <h3>${fullHeroData.character_name}</h3>
         <p>Level: ${fullHeroData.level}</p>
         <p>ATK: ${stats.atk} | HP: ${stats.hp}</p>
+        <p>Sell Price: ${sellPrice}g</p>
         <h4>Equipped Items</h4>
         <div class="equipped-slots">
             <p>Weapon: ${equippedItems[0]?.equipment_name || 'Empty'}</p>
@@ -1506,13 +1509,15 @@ async function updateEquipmentDisplay() {
     const equipmentDefsResponse = await fetch('/static/equipment.json');
     if (!equipmentDefsResponse.ok) return;
     const equipmentDefs = await equipmentDefsResponse.json();
-    const statsMap = equipmentDefs.reduce((map, item) => { map[item.name] = item.stat_bonuses; return map; }, {});
+    const statsMap = {};
+    const imageMap = {};
+    equipmentDefs.forEach(item => { statsMap[item.name] = item.stat_bonuses; imageMap[item.name] = item.image_file; });
     if (result.equipment.length === 0) {
         equipmentContainer.style.display = 'flex';
         equipmentContainer.style.justifyContent = 'center';
         equipmentContainer.style.alignItems = 'center';
         equipmentContainer.style.minHeight = '40vh';
-        equipmentContainer.innerHTML = '<p class="empty-armory-message">Your armory is empty. Farm the Armory to find loot, it is an end game mechanic.</p>';
+        equipmentContainer.innerHTML = '<p class="empty-armory-message">Your armory is empty. Items can be obtained in the dungeon.</p>';
         return;
     }
     equipmentContainer.removeAttribute('style');
@@ -1520,9 +1525,11 @@ async function updateEquipmentDisplay() {
         const card = document.createElement('div');
         card.className = 'collection-card';
         const stats = statsMap[item.equipment_name] || {};
+        const imgFile = imageMap[item.equipment_name];
+        const imgHtml = imgFile ? `<img loading="lazy" src="/static/images/items/${imgFile}" alt="${item.equipment_name}">` : '';
         const statsText = Object.entries(stats).map(([key, value]) => `${key.toUpperCase()}: +${value}`).join(' | ');
         const rarityClass = item.rarity.toLowerCase();
-        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${rarityClass}">[${item.rarity}]</div></div><h4>${item.equipment_name}</h4><p class="card-stats">${statsText}</p><div class="item-status">${item.is_equipped_on ? `Equipped` : 'Unequipped'}</div>`;
+        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${rarityClass}">[${item.rarity}]</div></div>${imgHtml}<h4>${item.equipment_name}</h4><p class="card-stats">${statsText}</p><div class="item-status">${item.is_equipped_on ? `Equipped` : 'Unequipped'}</div>`;
         equipmentContainer.appendChild(card);
     });
 }
@@ -1551,7 +1558,7 @@ async function updateExpeditionDisplay() {
             drops = `<p>Drops: ${nice.join(', ')}</p>`;
         }
         const desc = exp.description ? `<p>${exp.description}</p>` : '';
-        wrapper.innerHTML = `<div class="dungeon-image-container"><img src="${img}" alt="${exp.name}"></div><div class="dungeon-details-container"><h3>${exp.name}</h3>${desc}${drops}<button class="dungeon-fight-button" data-expedition-id="${exp.id}">Enter</button></div>`;
+        wrapper.innerHTML = `<div class="dungeon-image-container">${img ? `<img loading="lazy" src="${img}" alt="${exp.name}">` : ''}</div><div class="dungeon-details-container"><h3>${exp.name}</h3>${desc}${drops}<button class="dungeon-fight-button" data-expedition-id="${exp.id}">Enter</button></div>`;
         list.appendChild(wrapper);
     });
 }
@@ -1575,14 +1582,14 @@ async function updateAllUsers() {
     towerSorted.forEach((u, idx) => {
         const div = document.createElement('div');
         div.className = 'online-list-item';
-        const img = `<img class="score-profile" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
+        const img = `<img class="score-profile" loading="lazy" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
         div.innerHTML = `${img}${idx + 1}. ${u.username} - Floor ${u.current_stage}`;
         towerScoresContainer.appendChild(div);
     });
     dungeonSorted.forEach((u, idx) => {
         const div = document.createElement('div');
         div.className = 'online-list-item';
-        const img = `<img class="score-profile" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
+        const img = `<img class="score-profile" loading="lazy" src="/static/images/characters/${u.profile_image || 'placeholder_char.png'}" alt="${u.username}">`;
         div.innerHTML = `${img}${idx + 1}. ${u.username} - Runs ${u.dungeon_runs}`;
         dungeonScoresContainer.appendChild(div);
     });
@@ -1906,9 +1913,9 @@ function updateTeamDisplay() {
         if (member) {
             const element = member.element || 'None';
             const stats = getScaledStats(member);
-            slot.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${member.rarity.toLowerCase()}">[${member.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${member.image_file}" alt="${member.name}"><h4>${member.name}</h4><p>ATK: ${stats.atk} | HP: ${stats.hp}</p><p>Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</p>`;
+            slot.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${member.rarity.toLowerCase()}">[${member.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" loading="lazy" src="/static/images/characters/${member.image_file}" alt="${member.name}"><h4>${member.name}</h4><p>ATK: ${stats.atk} | HP: ${stats.hp}</p><p>Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</p>`;
         } else {
-            slot.innerHTML = `<img src="/static/images/ui/placeholder_char.png" alt="Empty"><h4>Empty Slot</h4>`;
+            slot.innerHTML = `<img loading="lazy" src="/static/images/ui/placeholder_char.png" alt="Empty"><h4>Empty Slot</h4>`;
         }
         teamDisplayContainer.appendChild(slot);
     }
@@ -1936,7 +1943,9 @@ function updateCollectionDisplay() {
         const canMerge = heroCounts[hero.character_name] >= mergeCost;
         const isInTeam = teamDBIds.includes(hero.id);
         const stats = getScaledStats(hero);
-        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level}</div><div class="card-stats">ATK: ${stats.atk} | HP: ${stats.hp}</div><div class="card-stats">Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button><button class="level-up-card-btn" data-hero-id="${hero.id}">Level Up (${100 * hero.level}g)</button><button class="sell-hero-btn" data-hero-id="${hero.id}">Sell</button></div>`;
+        const sellBase = { 'Common': 50, 'Rare': 150, 'SSR': 400, 'UR': 800, 'LR': 1500 };
+        const sellPrice = (sellBase[hero.rarity] || 50) * hero.level;
+        card.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${hero.rarity.toLowerCase()}">[${hero.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" loading="lazy" src="/static/images/characters/${charDef.image_file}" alt="${hero.character_name}"><h4>${hero.character_name}</h4><div class="card-stats">Level: ${hero.level}</div><div class="card-stats">ATK: ${stats.atk} | HP: ${stats.hp}</div><div class="card-stats">Crit: ${stats.crit}% | Crit DMG: ${stats.critDmg}x</div><div class="button-row"><button class="team-manage-button" data-char-id="${hero.id}" data-action="${isInTeam ? 'remove' : 'add'}">${isInTeam ? 'Remove' : 'Add'}</button><button class="merge-button" data-char-name="${hero.character_name}" ${canMerge ? '' : 'disabled'}>Merge</button><button class="equip-button" data-hero-id="${hero.id}">Equip</button><button class="level-up-card-btn" data-hero-id="${hero.id}">Level Up (${100 * hero.level}g)</button><button class="sell-hero-btn" data-hero-id="${hero.id}">Sell (${sellPrice}g)</button></div>`;
         if (isInTeam) {
             const indicator = document.createElement('div');
             indicator.className = 'in-team-indicator';
@@ -1993,7 +2002,7 @@ function updateCampaignDisplay() {
         // This new HTML structure matches the Armory layout
         stageItem.innerHTML = `
             <div class="stage-icon">
-                <img src="${iconPath}" alt="Status">
+                <img loading="lazy" src="${iconPath}" alt="Status">
             </div>
             <div class="stage-content">
                 ${titleHTML}
@@ -2055,11 +2064,11 @@ async function startBattle(fightResult) {
         const slot = document.createElement('div');
         slot.className = 'team-slot';
         const element = member.element || 'None';
-        slot.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${member.rarity.toLowerCase()}">[${member.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" src="/static/images/characters/${member.image_file}" alt="${member.name}"><h4>${member.name.split(',')[0]}</h4>`;
+        slot.innerHTML = `<div class="card-header"><div class="card-rarity rarity-${member.rarity.toLowerCase()}">[${member.rarity}]</div><div class="card-element element-${element.toLowerCase()}">${element}</div></div><img class="hero-portrait" loading="lazy" src="/static/images/characters/${member.image_file}" alt="${member.name}"><h4>${member.name.split(',')[0]}</h4>`;
         playerTeamContainer.appendChild(slot);
     });
 
-    enemyDisplayContainer.innerHTML = `<div class="team-slot"><img src="/static/images/${enemyImage}" alt="${enemyName}"><h4>${enemyName}</h4></div>`;
+    enemyDisplayContainer.innerHTML = `<div class="team-slot"><img loading="lazy" src="/static/images/${enemyImage}" alt="${enemyName}"><h4>${enemyName}</h4></div>`;
 
     const updateHealthBar = (bar, text, current, max) => {
         const percentage = Math.max(0, (current / max) * 100);

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,7 +46,7 @@
                 <p data-i18n>While the game works on mobile devices, the screens are optimized for computer usage.</p>
             </div>
             <div class="login-container">
-                <img src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">
+                <img loading="lazy" src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">
                 <div class="form-box">
                 <input type="text" id="username-input" placeholder="Username">
                 <input type="password" id="password-input" placeholder="Password">
@@ -84,7 +84,7 @@
         <!-- TOP BAR: Player Info -->
         <div id="top-bar">
             <div id="player-info">
-                <img id="user-icon" src="{{ url_for('static', filename='images/ui/placeholder_char.png') }}" alt="User Icon" class="user-icon clickable">
+                <img id="user-icon" loading="lazy" src="{{ url_for('static', filename='images/ui/placeholder_char.png') }}" alt="User Icon" class="user-icon clickable">
                 <span id="player-name" class="clickable"></span>
                 <button id="logout-button">Logout</button>
             </div>
@@ -118,7 +118,7 @@
                     <button class="tutorial-btn" data-tutorial="This home screen shows your active team and important progress information.">?</button>
                 </div>
                 <div class="daily-gift" id="gem-gift">
-                    <img src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
+                    <img loading="lazy" src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
                     <button id="gem-gift-button" class="gift-btn" data-i18n>Claim 50 Gems<span class="red-dot"></span></button>
                     <span id="gem-gift-timer"></span>
                 </div>
@@ -211,7 +211,7 @@
                     <button class="tutorial-btn" data-tutorial="Purchase Platinum or energy here. Transactions are verified server-side.">?</button>
                 </div>
                 <div class="daily-gift" id="platinum-gift">
-                    <img src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
+                    <img loading="lazy" src="{{ url_for('static', filename='images/ui/chest.png') }}" alt="Chest" />
                     <button id="platinum-gift-button" class="gift-btn" data-i18n>Daily Platinum Chest<span class="red-dot"></span></button>
                     <span id="platinum-gift-timer"></span>
                 </div>
@@ -255,7 +255,7 @@
         <!-- Column 2: The Tower Image -->
         <!-- We give it the 'dungeon-image-container' class to inherit its styling -->
         <div class="dungeon-image-container" id="tower-art-wrapper">
-            <img src="{{ url_for('static', filename='images/ui/tower_art.png') }}" alt="The Spire">
+            <img loading="lazy" src="{{ url_for('static', filename='images/ui/tower_art.png') }}" alt="The Spire">
         </div>
 
     </div>
@@ -539,7 +539,7 @@
 
 <div id="hero-image-overlay" class="modal-overlay">
     <div class="modal-content">
-        <img id="hero-image-large" src="" alt="Hero" style="max-width:300px; height:auto;">
+        <img id="hero-image-large" loading="lazy" src="" alt="Hero" style="max-width:300px; height:auto;">
         <button id="close-hero-image-btn">Close</button>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- show sell price for heroes in collection and detail modal
- skip equipment image when missing and add lazy loading
- tweak armory empty message
- add `scripts/optimize_images.py` helper and document image optimization
- lazy load images in the main UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ace4a579c8333813d07720e412119