### PR TITLE
Add account deletion and misc fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -592,6 +592,16 @@ def change_password():
     return jsonify({'success': True})
 
 
+@app.route('/api/delete_account', methods=['POST'])
+def delete_account():
+    if not session.get('logged_in'):
+        return jsonify({'success': False}), 401
+    user_id = session['user_id']
+    db.delete_user(user_id)
+    session.clear()
+    return jsonify({'success': True})
+
+
 @app.route('/api/player_data', methods=['GET'])
 def get_player_data():
     if not session.get('logged_in'): return jsonify({'success': False}), 401

--- a/database.py
+++ b/database.py
@@ -727,6 +727,18 @@ def reset_password(email, new_password):
 def adjust_resources(user_id, gems=None, premium_gems=None, energy=None, gold=None):
     save_player_data(user_id, gems=gems, premium_gems=premium_gems, energy=energy, gold=gold)
 
+def delete_user(user_id):
+    """Completely remove a user and related data."""
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute('DELETE FROM player_characters WHERE user_id = ?', (user_id,))
+    cur.execute('DELETE FROM player_equipment WHERE user_id = ?', (user_id,))
+    cur.execute('DELETE FROM player_team WHERE user_id = ?', (user_id,))
+    cur.execute('DELETE FROM player_data WHERE user_id = ?', (user_id,))
+    cur.execute('DELETE FROM users WHERE id = ?', (user_id,))
+    conn.commit()
+    conn.close()
+
 def remove_character(user_id, char_id):
     conn = get_db_connection()
     conn.execute("DELETE FROM player_characters WHERE id = ? AND user_id = ?", (char_id, user_id))

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -366,6 +366,7 @@ button:disabled, .fantasy-button:disabled {
 }
 #chat-container.collapsed {
     height: 40px;
+    bottom: 160px;
 }
 #chat-container.collapsed #chat-messages,
 #chat-container.collapsed #chat-input-area {
@@ -854,7 +855,7 @@ button:disabled, .fantasy-button:disabled {
     width: 80%;
     max-width: 900px; /* Give it a max width on large screens */
     height: 150px;
-    background-color: rgba(0, 0, 0, 0.6);
+    background-color: #000;
     border: 1px solid #444;
     border-radius: 8px;
     margin: 20px auto 0 auto; /* Center it horizontally */

--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -158,5 +158,12 @@
   "PayPal unavailable": "PayPal no disponible",
   "Purchase successful!": "Compra exitosa",
   "Purchase failed": "Compra fallida",
-  "Failed to load store.": "No se pudo cargar la tienda"
+  "Failed to load store.": "No se pudo cargar la tienda",
+  "Delete Account": "Eliminar cuenta",
+  "Are you sure you want to delete your account?": "¿Está seguro de que desea eliminar su cuenta?",
+  "Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store.": "Gemas - Se obtienen en eventos y mazmorras. Gástalas en el Altar de Invocación o compra más en la Tienda.",
+  "Platinum - Purchased with real money. Use it for energy refills and special packs.": "Platino - Se compra con dinero real. Úsalo para recargas de energía y paquetes especiales.",
+  "Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.": "Oro - Se obtiene en batallas y vendiendo héroes. Gástalo para subir de nivel héroes y equipo.",
+  "Energy - Regenerates every 5 minutes or with Platinum. Required for Tower battles.": "Energía - Se regenera cada 5 minutos o con Platino. Necesaria para las batallas de la Torre.",
+  "Dungeon Energy - Regenerates every 15 minutes or with Platinum. Required for Armory expeditions.": "Energía de Mazmorra - Se regenera cada 15 minutos o con Platino. Necesaria para expediciones del Arsenal."
 }

--- a/static/i18n/ja.json
+++ b/static/i18n/ja.json
@@ -158,5 +158,12 @@
   "PayPal unavailable": "PayPal利用不可",
   "Purchase successful!": "購入成功",
   "Purchase failed": "購入失敗",
-  "Failed to load store.": "ストア読み込み失敗"
+  "Failed to load store.": "ストア読み込み失敗",
+  "Delete Account": "アカウント削除",
+  "Are you sure you want to delete your account?": "本当にアカウントを削除しますか？",
+  "Gems - Earned from events and dungeons. Spend them at the Summoning Altar or purchase more in the Store.": "ジェム - イベントやダンジョンで獲得。召喚祭壇で使用するか、ストアで購入できます。",
+  "Platinum - Purchased with real money. Use it for energy refills and special packs.": "プラチナ - 実際のお金で購入。エネルギー回復や特別なパックに使用します。",
+  "Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.": "ゴールド - 戦闘やヒーロー売却で獲得。ヒーローや装備の強化に使用します。",
+  "Energy - Regenerates every 5 minutes or with Platinum. Required for Tower battles.": "エネルギー - 5分ごとまたはプラチナで回復。塔の戦闘に必要です。",
+  "Dungeon Energy - Regenerates every 15 minutes or with Platinum. Required for Armory expeditions.": "ダンジョンエネルギー - 15分ごとまたはプラチナで回復。遠征に必要です。"
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -88,6 +88,7 @@ let profileConfirmPasswordInput;
 let profileImageSelect;
 let profileLanguageSelect;
 let profileSaveBtn;
+let profileDeleteBtn;
 let gameEnergyCapInput;
 let gameDungeonCapInput;
 let gameEnergyRegenInput;
@@ -395,6 +396,7 @@ function attachEventListeners() {
     profileImageSelect = document.getElementById('profile-image-select');
     profileLanguageSelect = document.getElementById('profile-language-select');
     profileSaveBtn = document.getElementById('profile-save-btn');
+    profileDeleteBtn = document.getElementById('profile-delete-btn');
     profileCancelBtn = document.getElementById('profile-cancel-btn');
     adminSubmitBtn = document.getElementById('admin-submit-btn');
     paypalClientIdInput = document.getElementById('admin-paypal-client-id');
@@ -603,9 +605,9 @@ function attachEventListeners() {
 
     document.querySelectorAll('#currency-info .currency-icon').forEach(icon => {
         icon.classList.add('clickable');
-        icon.addEventListener('click', () => {
+        icon.addEventListener('click', async () => {
             const msg = iconMessages[icon.id] || '';
-            if (infoText) infoText.textContent = msg;
+            if (infoText) infoText.textContent = await translateText(msg);
             if (infoModal) infoModal.classList.add('active');
         });
     });
@@ -651,6 +653,17 @@ function attachEventListeners() {
             profileCurrentPasswordInput.value = '';
             profileNewPasswordInput.value = '';
             profileConfirmPasswordInput.value = '';
+        }
+    });
+    if (profileDeleteBtn) profileDeleteBtn.addEventListener('click', async () => {
+        const confirmMsg = await translateText('Are you sure you want to delete your account?');
+        if (!confirm(confirmMsg)) return;
+        const resp = await fetch('/api/delete_account', { method: 'POST' });
+        const result = await resp.json();
+        if (result.success) {
+            await handleLogout();
+        } else {
+            displayMessage(result.message || 'Deletion failed');
         }
     });
     if (adminSubmitBtn) adminSubmitBtn.addEventListener('click', async () => {

--- a/static/js/translate.js
+++ b/static/js/translate.js
@@ -20,6 +20,24 @@ function markTranslatable() {
 
 const translationsCache = {};
 
+async function getDict(lang) {
+    lang = (lang || '').toLowerCase();
+    if (lang === 'jp' || lang === 'ja-jp') lang = 'ja';
+    if (lang === 'en') return null;
+    if (!translationsCache[lang]) {
+        await loadTranslations(lang);
+    }
+    return translationsCache[lang];
+}
+
+async function translateText(text, lang) {
+    lang = lang || localStorage.getItem('language') || 'en';
+    const dict = await getDict(lang);
+    if (!dict) return text;
+    const key = text.trim().replace(/\s+/g, ' ');
+    return dict[key] || text;
+}
+
 async function loadTranslations(lang) {
     lang = (lang || '').toLowerCase();
     if (lang === 'jp' || lang === 'ja-jp') lang = 'ja';
@@ -61,3 +79,4 @@ async function translatePage(lang) {
 }
 
 window.translatePage = translatePage;
+window.translateText = translateText;

--- a/templates/index.html
+++ b/templates/index.html
@@ -570,6 +570,7 @@
         <p class="tos-link"><a href="/tos" target="_blank" data-i18n>View Terms and Conditions</a></p>
         <div class="modal-buttons">
             <button id="profile-save-btn" data-i18n>Save</button>
+            <button id="profile-delete-btn" data-i18n>Delete Account</button>
             <button id="profile-cancel-btn" data-i18n>Cancel</button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add delete_account API and button in profile modal
- new DB helper to remove user data
- translate info messages with translateText helper
- adjust world chat collapsed position
- set combat log background to black
- update JP and ES translations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adc5f02f883338c960cd7a53d5075