### PR TITLE
Fix combat log health check and prevent redundant menu reloads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1320,6 +1320,7 @@ def fight():
             if is_player_crit:
                 player_damage *= attacker['crit_damage']
             enemy_hp -= player_damage
+            enemy_hp = round(enemy_hp, 2)
             combat_log.append({
                 'type': 'player_attack',
                 'crit': is_player_crit,
@@ -1336,6 +1337,7 @@ def fight():
             if is_enemy_crit:
                 enemy_damage *= stats['enemy_crit_damage']
             team_hp -= enemy_damage
+            team_hp = round(team_hp, 2)
             combat_log.append({'type': 'enemy_attack',
                                'crit': is_enemy_crit,
                                'damage': int(enemy_damage),
@@ -1469,6 +1471,7 @@ def fight_dungeon():
                 if is_player_crit:
                     player_damage *= attacker['crit_damage']
                 enemy_hp -= player_damage
+                enemy_hp = round(enemy_hp, 2)
                 combat_log.append({
                     'type': 'player_attack',
                     'crit': is_player_crit,
@@ -1485,6 +1488,7 @@ def fight_dungeon():
                 if is_enemy_crit:
                     enemy_damage *= stats['enemy_crit_damage']
                 team_hp -= enemy_damage
+                team_hp = round(team_hp, 2)
                 combat_log.append({'type': 'enemy_attack',
                                    'crit': is_enemy_crit,
                                    'damage': int(enemy_damage),

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -14,6 +14,7 @@ let gameState = {};
 let masterCharacterList = [];
 let socket;
 let currentStageForFight = 0;
+let currentViewId = 'home-view';
 
 // --- DOM ELEMENT REFERENCES ---
 const loginScreen = document.getElementById('login-screen');
@@ -967,6 +968,8 @@ function attachEventListeners() {
     navButtons.forEach(button => {
         button.addEventListener('click', () => {
             const targetViewId = button.dataset.view;
+            if (currentViewId === targetViewId) return;
+            currentViewId = targetViewId;
             mainContent.querySelectorAll('.view').forEach(view => view.classList.remove('active'));
             document.getElementById(targetViewId)?.classList.add('active');
             applyBodyBackground(targetViewId);


### PR DESCRIPTION
## Summary
- ensure HP values are rounded to avoid enemy attacks when HP shows as 0
- keep track of active view and ignore duplicate nav clicks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ae22db20c83338cab0d616a5a62b9