### PR TITLE
Improve portrait mobile layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -356,7 +356,6 @@ button:disabled, .fantasy-button:disabled {
     justify-content: space-between;
     align-items: center;
     padding: 5px 10px;
-    border-bottom: 1px solid #444;
 }
 #chat-toggle-btn {
     background: none;
@@ -375,12 +374,14 @@ button:disabled, .fantasy-button:disabled {
 #chat-container h3 {
     text-align: center;
     padding: 10px;
-    border-bottom: 1px solid #444;
+    /* Removed border-bottom to avoid double lines under header */
 }
 #chat-messages {
     flex-grow: 1;
     padding: 10px;
     overflow-y: auto;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 #chat-messages div {
     margin-bottom: 5px;
@@ -1463,6 +1464,11 @@ button:disabled, .fantasy-button:disabled {
     border-radius: 5px;
     display: none;
     z-index: 1000;
+    max-width: 90%;
+    max-height: 60vh;
+    overflow-y: auto;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* Store styles */
@@ -1583,11 +1589,34 @@ button:disabled, .fantasy-button:disabled {
         height: auto;
         min-height: 100vh;
     }
+    /* Login screen stacks vertically on small screens */
+    #login-wrapper {
+        flex-direction: column;
+        align-items: center;
+    }
+    .login-lore-box {
+        margin-right: 0;
+        margin-bottom: 15px;
+    }
+    #login-screen input {
+        width: 80%;
+        max-width: 250px;
+    }
     #nav-bar {
         height: 60px;
+        flex-wrap: wrap;
     }
     .nav-button {
-        font-size: 16px;
+        font-size: 14px;
+        flex: 1 0 33%;
+    }
+    #top-bar {
+        flex-direction: column;
+        height: auto;
+    }
+    #player-info, #currency-info {
+        flex-wrap: wrap;
+        justify-content: center;
     }
     .team-container {
         flex-wrap: wrap;
@@ -1604,5 +1633,6 @@ button:disabled, .fantasy-button:disabled {
         bottom: 110px;
         font-size: 14px;
         max-width: 90%;
+        max-height: 70vh;
     }
 }

--- a/static/i18n/ja.json
+++ b/static/i18n/ja.json
@@ -132,7 +132,7 @@
   "New Expedition": "新遠征",
   "Use enemy": "敵を使用",
   "Drops follow": "ドロップは次の通り",
-  "pairs (e.g. sword:0.5), and image resolution is": "例: sword:0.5) 画像サイズは",
+  "pairs (e.g. sword:0.5), and image resolution is": "例: sword:0.5) 画像解像度は",
   "separated by commas (e.g. EN001, EN008).": "カンマ区切り (例: EN001, EN008)",
   "terms and conditions": "利用規約",
   "I have read and accept the": "私は読み同意しました",
@@ -153,7 +153,7 @@
   "Last updated: June 27, 2025": "最終更新: 2025年6月27日",
   "Loading...": "読み込み中...",
   "(Floor": "(階",
-  "150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.": "150個で新しいヒーローを召喚! 確率: コモン50%, レア30%, SSR15%, UR3.5%, LR1.5%。90回でSSR確定。"
+  "150 to summon a new hero! Odds: 50% Common, 30% Rare, 15% SSR, 3.5% UR, 1.5% LR. Guaranteed SSR every 90 summons.": "150個で新しいヒーローを召喚! 確率: コモン50%, レア30%, SSR15%, UR3.5%, LR1.5%。90回でSSR確定。",
   "Buy": "購入",
   "PayPal unavailable": "PayPal利用不可",
   "Purchase successful!": "購入成功",

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
                 </p>
                 <p data-i18n>Thank you for playing and sharing this journey with us!</p>
                 <p data-i18n>You can contact the team at <a href="mailto:contact@towerchronicles.xyz">contact@towerchronicles.xyz</a>.</p>
-                <p data-i18n>While the game works on mobile devices, the screens are optimized for computer usage.</p>
+                <p data-i18n>The interface adapts to portrait mobile screens but works best on a larger display.</p>
             </div>
             <div class="login-container">
                 <img src="{{ url_for('static', filename='images/ui/game_logo.png') }}" alt="Game Logo" class="game-logo">


### PR DESCRIPTION
## Summary
- update login message about mobile support
- improve portrait mode with CSS tweaks
- polish chat layout and prevent overflow
- fix invalid Japanese translation file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b0bf1139c8333b76b116622ff1898