### PR TITLE
Switch favicon to webp

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Aethelgard Chronicles - Web Edition</title>
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='images/ui/game_icon.webp') }}">
+    <link rel="icon" type="image/webp" href="{{ url_for('static', filename='images/ui/game_icon.webp') }}">
 
 
     <!-- Load JRPG styled font -->


### PR DESCRIPTION
## Summary
- use `image/webp` for favicon type

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872c35e6ac48333ac622d1739f3a0d5