### PR TITLE
Improve empty states and chat access

### DIFF
--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -75,6 +75,7 @@
   "Retry": "Reintentar",
   "Return": "Regresar",
   "World Chat": "Chat mundial",
+  "Chat": "Chat",
   "Send": "Enviar",
   "Stage Intel": "Información de la fase",
   "Change Team": "Cambiar equipo",
@@ -166,4 +167,6 @@
   "Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.": "Oro - Se obtiene en batallas y vendiendo héroes. Gástalo para subir de nivel héroes y equipo.",
   "Energy - Regenerates every 5 minutes or with Platinum. Required for Tower battles.": "Energía - Se regenera cada 5 minutos o con Platino. Necesaria para las batallas de la Torre.",
   "Dungeon Energy - Regenerates every 15 minutes or with Platinum. Required for Armory expeditions.": "Energía de Mazmorra - Se regenera cada 15 minutos o con Platino. Necesaria para expediciones del Arsenal."
+  ,"No friends yet. Visit the Players tab and tap a username to send a request.": "Aún no tienes amigos. Ve a la pestaña Jugadores y toca un nombre para enviar una solicitud."
+  ,"No mail yet. Messages from friends and the system will appear here. Send mail from a friend's profile.": "Aún no tienes correo. Los mensajes de amigos y del sistema aparecerán aquí. Envía correos desde el perfil de un amigo."
 }

--- a/static/i18n/ja.json
+++ b/static/i18n/ja.json
@@ -75,6 +75,7 @@
   "Retry": "再試行",
   "Return": "戻る",
   "World Chat": "ワールドチャット",
+  "Chat": "チャット",
   "Send": "送信",
   "Stage Intel": "ステージ情報",
   "Change Team": "チーム変更",
@@ -166,4 +167,6 @@
   "Gold - Earned from battles and selling heroes. Spend it to level up heroes and equipment.": "ゴールド - 戦闘やヒーロー売却で獲得。ヒーローや装備の強化に使用します。",
   "Energy - Regenerates every 5 minutes or with Platinum. Required for Tower battles.": "エネルギー - 5分ごとまたはプラチナで回復。塔の戦闘に必要です。",
   "Dungeon Energy - Regenerates every 15 minutes or with Platinum. Required for Armory expeditions.": "ダンジョンエネルギー - 15分ごとまたはプラチナで回復。遠征に必要です。"
+  ,"No friends yet. Visit the Players tab and tap a username to send a request.": "まだフレンドがいません。プレイヤーのタブで名前をタップして申請しましょう。"
+  ,"No mail yet. Messages from friends and the system will appear here. Send mail from a friend's profile.": "まだメールはありません。フレンドやシステムからのメッセージがここに表示されます。フレンドのプロフィールからメールを送信できます。"
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -61,6 +61,7 @@ const onlineListContainer = document.getElementById('online-list-container');
 const towerScoresContainer = document.getElementById('tower-highscores');
 const dungeonScoresContainer = document.getElementById('dungeon-highscores');
 const navButtons = document.querySelectorAll('.nav-button');
+const chatNavButton = document.getElementById('chat-nav-button');
 const chatMessages = document.getElementById('chat-messages');
 const chatInput = document.getElementById('chat-input');
 const chatSendButton = document.getElementById('chat-send-button');
@@ -336,6 +337,12 @@ async function updateFriendList() {
     const data = await resp.json();
     if (!data.success) return;
     friendListContainer.innerHTML = '';
+    if (!data.friends.length) {
+        const p = document.createElement('p');
+        p.textContent = await translateText('No friends yet. Visit the Players tab and tap a username to send a request.');
+        friendListContainer.appendChild(p);
+        return;
+    }
     data.friends.forEach(f => {
         const div = document.createElement('div');
         div.textContent = `${f.username} - ${f.status}`;
@@ -349,6 +356,12 @@ async function updateMailList() {
     const data = await resp.json();
     if (!data.success) return;
     mailListContainer.innerHTML = '';
+    if (!data.mail.length) {
+        const p = document.createElement('p');
+        p.textContent = await translateText('No mail yet. Messages from friends and the system will appear here. Send mail from a friend\'s profile.');
+        mailListContainer.appendChild(p);
+        return;
+    }
     data.mail.forEach(m => {
         const div = document.createElement('div');
         const sender = m.sender_id ? `From ${m.sender_id}` : 'System';
@@ -1011,6 +1024,11 @@ function attachEventListeners() {
         chatToggleBtn.addEventListener('click', () => {
             chatContainer.classList.toggle('collapsed');
             chatToggleBtn.textContent = chatContainer.classList.contains('collapsed') ? '▴' : '▾';
+        });
+    }
+    if (chatNavButton) {
+        chatNavButton.addEventListener('click', () => {
+            chatContainer.classList.toggle('hidden');
         });
     }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -471,6 +471,7 @@
             <button class="nav-button" data-view="online-view" data-i18n>Players</button>
             <button class="nav-button" data-view="friends-view" data-i18n>Friends</button>
             <button class="nav-button" data-view="mail-view" data-i18n>Mail</button>
+            <button class="nav-button" id="chat-nav-button" data-i18n>Chat</button>
             <button class="nav-button" data-view="tasks-view" data-i18n>Missions</button>
             <button class="nav-button admin-only" data-view="admin-view" data-i18n>Admin</button>
             <button class="nav-button" data-view="store-view" data-i18n>Store<span class="red-dot"></span></button>


### PR DESCRIPTION
## Summary
- show help text when friends or mail are empty
- translate the new messages
- add a `Chat` nav button
- toggle chat via the new button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68753b5d7e9483338107807e5926ab7a