### PR TITLE
Improve equipment system with drag-and-drop slots

### DIFF
--- a/app.py
+++ b/app.py
@@ -1152,8 +1152,12 @@ def equip_item():
     user_id, data = session['user_id'], request.json
     equipment_id, character_id = data.get('equipment_id'), data.get('character_id')
     conn = db.get_db_connection()
-    conn.execute('UPDATE player_equipment SET is_equipped_on = NULL WHERE is_equipped_on = ? AND user_id = ?',
-                 (character_id, user_id))
+    row = conn.execute('SELECT slot_type FROM player_equipment WHERE id = ? AND user_id = ?',
+                       (equipment_id, user_id)).fetchone()
+    slot_type = row['slot_type'] if row else None
+    if slot_type:
+        conn.execute('UPDATE player_equipment SET is_equipped_on = NULL WHERE is_equipped_on = ? AND user_id = ? AND slot_type = ?',
+                     (character_id, user_id, slot_type))
     conn.execute('UPDATE player_equipment SET is_equipped_on = ? WHERE id = ? AND user_id = ?',
                  (character_id, equipment_id, user_id))
     conn.commit()

--- a/blueprints/game.py
+++ b/blueprints/game.py
@@ -193,8 +193,8 @@ def fight_dungeon():
                             }
                             conn = db.get_db_connection()
                             conn.execute(
-                                "INSERT INTO player_equipment (user_id, equipment_name, rarity) VALUES (?, ?, ?)",
-                                (user_id, looted_item['name'], looted_item['rarity'])
+                                "INSERT INTO player_equipment (user_id, equipment_name, rarity, slot_type) VALUES (?, ?, ?, ?)",
+                                (user_id, looted_item['name'], looted_item['rarity'], item_def.get('type'))
                             )
                             conn.commit()
                             conn.close()
@@ -210,8 +210,8 @@ def fight_dungeon():
                 }
                 conn = db.get_db_connection()
                 conn.execute(
-                    "INSERT INTO player_equipment (user_id, equipment_name, rarity) VALUES (?, ?, ?)",
-                    (user_id, looted_item['name'], looted_item['rarity'])
+                    "INSERT INTO player_equipment (user_id, equipment_name, rarity, slot_type) VALUES (?, ?, ?, ?)",
+                    (user_id, looted_item['name'], looted_item['rarity'], looted_item_def.get('type'))
                 )
                 conn.commit()
                 conn.close()

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1452,6 +1452,36 @@ button:disabled, .fantasy-button:disabled {
     margin: 10px 0;
 }
 
+#hero-detail-content .equip-slots {
+    display: flex;
+    gap: 10px;
+    margin: 10px 0;
+}
+#hero-detail-content .equip-slot {
+    width: 80px;
+    height: 80px;
+    border: 2px dashed #555;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+#hero-detail-content .equip-slot img {
+    width: 70px;
+    height: 70px;
+}
+#hero-detail-content .inventory {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+}
+#hero-detail-content .inventory img {
+    width: 60px;
+    height: 60px;
+    cursor: grab;
+}
+
 /* transient message box for alerts */
 #message-box {
     position: fixed;

--- a/static/equipment.json
+++ b/static/equipment.json
@@ -68,7 +68,7 @@
   },
   {
     "name": "Reinforced Buckler",
-    "type": "Shield",
+    "type": "Armor",
     "rarity": "Uncommon",
     "stat_bonuses": {
       "hp": 80
@@ -120,5 +120,25 @@
     },
     "image_file": "dragon_scale_armor.webp",
     "code": "IT012"
+  },
+  {
+    "name": "Lucky Charm",
+    "type": "Trinket",
+    "rarity": "Common",
+    "stat_bonuses": {
+      "crit_chance": 2
+    },
+    "image_file": "lucky_charm.webp",
+    "code": "IT013"
+  },
+  {
+    "name": "Ancient Amulet",
+    "type": "Trinket",
+    "rarity": "Rare",
+    "stat_bonuses": {
+      "atk": 20
+    },
+    "image_file": "ancient_amulet.webp",
+    "code": "IT014"
   }
 ]


### PR DESCRIPTION
## Summary
- extend `player_equipment` schema with `slot_type`
- add trinket items and unify shield item as armor
- show equipment slot type and enable drag-and-drop equipping
- allow per-slot equipping on the backend
- style new equipment slots in the hero detail modal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753fc3ccb48333bf7ddfa30c89e939