### PR TITLE
Fix PayPal credit card form width

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1484,9 +1484,11 @@ button:disabled, .fantasy-button:disabled {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
+    flex-wrap: wrap;
 }
 .store-package div[id^="paypal-"] {
-    max-width: 160px;
+    min-width: 160px;
+    max-width: 100%;
 }
 .store-package .paypal-buttons {
     width: 100%;


### PR DESCRIPTION
## Summary
- let store packages wrap content and allow PayPal elements to expand

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68790d2de6508333a996bf7af2333e46